### PR TITLE
fix: Remove extra calendar update call

### DIFF
--- a/frappe_appointment/overrides/event_override.py
+++ b/frappe_appointment/overrides/event_override.py
@@ -168,7 +168,6 @@ def create_event_for_appointment_group(
 			}
 		):
 			return frappe.throw(_("Unable to Update an event"))
-		update_event_in_google_calendar(event)
 		return frappe.msgprint("Interview has been Re-Scheduled.")
 	calendar_event = {
 		"doctype": "Event",


### PR DESCRIPTION
`no-docs`