### PR TITLE
Check if google calendar is authorized [

### DIFF
--- a/frappe_appointment/frappe_appointment/doctype/user_appointment_availability/user_appointment_availability.py
+++ b/frappe_appointment/frappe_appointment/doctype/user_appointment_availability/user_appointment_availability.py
@@ -1,9 +1,15 @@
 # Copyright (c) 2023, rtCamp and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe.model.document import Document
 
 
 class UserAppointmentAvailability(Document):
-	pass
+    def validate(self):
+
+        calendar = frappe.get_doc("Google Calendar", self.google_calendar)
+        if not calendar.custom_is_google_calendar_authorized:
+            frappe.throw(
+                "Please authorize Google Calendar before creating appointment availability."
+            )


### PR DESCRIPTION
- https://github.com/rtCamp/frappe-appointment/issues/69

Don't allow user to create User appointment availability if google calendar of user is not authorized