### PR TITLE
feat: update reminder mail function to send emails only when Google Calendar is enabled 

### DIFF
--- a/frappe_appointment/tasks/reminder_google_calendar_auth.py
+++ b/frappe_appointment/tasks/reminder_google_calendar_auth.py
@@ -14,7 +14,7 @@ def send_reminder_mail():
         if not setup_reminder_template():
             return
 
-        google_calendars = frappe.get_all("Google Calendar")
+        google_calendars = frappe.get_all("Google Calendar", {"enable": 1})
 
         for google_calendar in google_calendars:
             google_calendar = frappe.get_doc("Google Calendar", google_calendar.name)


### PR DESCRIPTION
- Update reminder mail function to send emails only when Google Calendar is enabled (https://github.com/rtCamp/erp-rtcamp/issues/1973)