### PR TITLE
Update algorithm to only add buffer if we have Google event schedule

### DIFF
--- a/frappe_appointment/frappe_appointment/doctype/appointment_group/appointment_group.py
+++ b/frappe_appointment/frappe_appointment/doctype/appointment_group/appointment_group.py
@@ -554,7 +554,7 @@ def get_avaiable_time_slot_for_day(
         if index >= len(all_slots) and current_end_time <= endtime:
             available_slots.append({"start_time": current_start_time, "end_time": current_end_time})
 
-            current_start_time = get_next_round_value(minimum_buffer_time, current_end_time)
+            current_start_time = get_next_round_value(minimum_buffer_time, current_end_time, False)
             current_end_time = add_to_date(current_start_time, hours=hour, minutes=minute, seconds=second)
 
             continue
@@ -570,7 +570,7 @@ def get_avaiable_time_slot_for_day(
             currernt_slot["is_frappe_event"],
         ):
             available_slots.append({"start_time": current_start_time, "end_time": current_end_time})
-            current_start_time = get_next_round_value(minimum_buffer_time, current_end_time)
+            current_start_time = get_next_round_value(minimum_buffer_time, current_end_time, False)
         else:
             current_start_time = get_next_round_value(
                 minimum_buffer_time,


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->

This PR removes the function of adding buffer time for non-scheduled events. Now, buffer time will only be added when there is a Google event.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->

https://github.com/user-attachments/assets/bf13313e-d154-4797-9b0a-e360a9e0967f

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #