### PR TITLE
Update event endpoint to handle reschedule with event token

### DIFF
--- a/frappe_appointment/overrides/event_override.py
+++ b/frappe_appointment/overrides/event_override.py
@@ -276,19 +276,21 @@ def create_event_for_appointment_group(
             event.starts_on = starts_on
             event.ends_on = ends_on
             event.event_info = event_info
-            event.save(ignore_permissions=True)
 
-            # clear all previous logs
-            clear_messages()
-
-            if not event.handle_webhook(
+            webhook_call = event.handle_webhook(
                 {
                     "event": event.as_dict(),
                     "appointment_group": appointment_group.as_dict(),
                     "metadata": event_info,
                 }
-            ):
-                return frappe.throw(_("Unable to Update an event"))
+            )
+            if not webhook_call["status"]:
+                return frappe.throw(webhook_call["message"])
+
+            event.save(ignore_permissions=True)
+
+            # clear all previous logs
+            clear_messages()
 
             if success_message:
                 return frappe.msgprint(success_message)


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->

This PR fixes the rescheduling event function by using the `event_id` to update the event information. It also updates the main endpoint to give other apps the option to change the `success message` with arguments.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

Please check the whole appointment booking functions:
- Check if able to book an appointment or not
- Check if reschedule is working fine or not (Note: you will need to pass encrypted event_id as `event_token` in the link for reschedule)
- Exmple: `http://localhost/appointment/java-interview?reschedule=1&event_token=gAAAAABnpJdYiyM5blV1DCruB6NGwJ81ZLblnOV_u4Rj9nDPdmsEP1RyKSfMjDraNHWvz1HnmbAQLPGCnLqZe_PEzOkQ_zGCGA`

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->