### PR TITLE
 Update event endpoint to handle reschedule with event token

### DIFF
--- a/frappe_appointment/overrides/event_override.py
+++ b/frappe_appointment/overrides/event_override.py
@@ -9,6 +9,7 @@ from frappe.desk.doctype.event.event import Event
 from frappe.integrations.doctype.google_calendar.google_calendar import (
     get_google_calendar_object,
 )
+from frappe.twofactor import decrypt
 from frappe.utils import get_datetime, now
 
 from frappe_appointment.constants import (
@@ -223,6 +224,7 @@ def create_event_for_appointment_group(
     end_time: str,
     user_timezone_offset: str,
     event_participants,
+    success_message="",
     **args,
 ):
     """API Endpoint to Create the Event
@@ -264,24 +266,38 @@ def create_event_for_appointment_group(
     google_calendar_api_obj, account = get_google_calendar_object(appointment_group.event_creator)
 
     if reschedule:
-        event = frappe.get_last_doc("Event", filters={"custom_appointment_group": appointment_group.name})
-        event.starts_on = starts_on
-        event.ends_on = ends_on
-        event.event_info = event_info
-        event.save(ignore_permissions=True)
+        try:
+            event_id = decrypt(event_info.get("event_token"))
+            if not event_id:
+                return frappe.throw(_("Unable to Update an event"))
 
-        # clear all previous logs
-        clear_messages()
+            event = frappe.get_doc("Event", event_id)
 
-        if not event.handle_webhook(
-            {
-                "event": event.as_dict(),
-                "appointment_group": appointment_group.as_dict(),
-                "metadata": event_info,
-            }
-        ):
+            event.starts_on = starts_on
+            event.ends_on = ends_on
+            event.event_info = event_info
+
+            webhook_call = event.handle_webhook(
+                {
+                    "event": event.as_dict(),
+                    "appointment_group": appointment_group.as_dict(),
+                    "metadata": event_info,
+                }
+            )
+            if not webhook_call["status"]:
+                return frappe.throw(webhook_call["message"])
+
+            event.save(ignore_permissions=True)
+
+            # clear all previous logs
+            clear_messages()
+
+            if success_message:
+                return frappe.msgprint(success_message)
+
+            return frappe.msgprint(_("Event has been updated successfully."))
+        except Exception:
             return frappe.throw(_("Unable to Update an event"))
-        return frappe.msgprint(_("Interview has been Re-Scheduled."))
 
     calendar_event = {
         "doctype": "Event",
@@ -318,6 +334,9 @@ def create_event_for_appointment_group(
 
     # nosemgrep
     frappe.db.commit()
+
+    if success_message:
+        return frappe.msgprint(success_message)
 
     return _("Event has been created")
 


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->

This PR fixes the rescheduling event function by using the `event_id` to update the event information. It also updates the main endpoint to give other apps the option to change the `success message` with arguments.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

Please check the whole appointment booking functions:
- Check if able to book an appointment or not
- Check if reschedule is working fine or not (Note: you will need to pass encrypted event_id as `event_token` in the link for reschedule)
- Exmple: `http://localhost/appointment/java-interview?reschedule=1&event_token=gAAAAABnpJdYiyM5blV1DCruB6NGwJ81ZLblnOV_u4Rj9nDPdmsEP1RyKSfMjDraNHWvz1HnmbAQLPGCnLqZe_PEzOkQ_zGCGA`

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->