### PR TITLE
Fix relative width of availability slots

### DIFF
--- a/frontend/src/pages/appointment/components/booking.tsx
+++ b/frontend/src/pages/appointment/components/booking.tsx
@@ -252,7 +252,7 @@ const Booking = ({ type, banner }: BookingProp) => {
             {/* Main */}
             <div className="w-full flex max-lg:flex-col max-md:p-4 gap-8 items-start overflow-hidden ">
               {/* Profile */}
-              <div className="w-full md:max-w-sm flex flex-col gap-4 md:p-6 md:px-4">
+              <div className="max-lg:w-full md:min-w-sm md:max-w-sm flex flex-col gap-4 md:p-6 md:px-4">
                 <div className="w-full flex flex-col gap-1">
                   <Typography variant="h2" className="text-3xl font-semibold">
                     <Tooltip>
@@ -301,7 +301,7 @@ const Booking = ({ type, banner }: BookingProp) => {
                   )}
                 </div>
               </div>
-              <div className="w-full md:max-h-[30rem] md:overflow-hidden">
+              <div className="max-lg:w-full shrink-0 md:max-h-[30rem] md:overflow-hidden">
                 {/* Calendar and Availability slots */}
                 <AnimatePresence mode="wait">
                   {!state.showMeetingForm && (
@@ -426,7 +426,7 @@ const Booking = ({ type, banner }: BookingProp) => {
                       {/* Available slots */}
                       <div
                         className={cn(
-                          "w-48 max-lg:w-full overflow-hidden space-y-4 max-md:pb-10  transition-all duration-300 ",
+                          "w-48 shrink-0 max-lg:w-full overflow-hidden space-y-4 max-md:pb-10  transition-all duration-300 ",
                           !state.expanded && "max-md:hidden",
                           state.showReschedule &&
                             "lg:flex lg:flex-col lg:justify-between"

--- a/frontend/src/pages/appointment/components/skeletons.tsx
+++ b/frontend/src/pages/appointment/components/skeletons.tsx
@@ -7,7 +7,7 @@ import { Skeleton } from "@/components/skeleton";
 export function ProfileSkeleton() {
   return (
     <Card className="border-0 shadow-none">
-      <CardContent className="max-md:p-0 p-6 flex flex-col space-y-7 items-center">
+      <CardContent className="max-md:p-4 p-6 flex flex-col space-y-7 items-center">
         <Skeleton className="md:h-32 md:w-32 h-24 w-24 object-cover mb-4 md:mb-0  rounded-full" />
         <div className="flex flex-col space-y-2 w-full items-center">
           <Skeleton className="h-8 w-full" />


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->

## Relevant Technical Choices

This PR fixes layout of availability_slots by adding `shrink-0` to the parent div

## Testing Instructions

- Visit personal_meeting page and observe layout changes

## Additional Information:

N/A

## Screenshot/Screencast

Before:
![image](https://github.com/user-attachments/assets/7a071638-bf1f-415f-9413-11b2f0fcfbcc)

After:
![image](https://github.com/user-attachments/assets/1946b425-7ce2-4086-ad69-c7ecd6e97027)


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

