### PR TITLE
Fix: Convert duration to integer in Zoom meeting creation and update functions

### DIFF
--- a/frappe_appointment/helpers/zoom.py
+++ b/frappe_appointment/helpers/zoom.py
@@ -66,7 +66,7 @@ def create_meeting(
         "topic": subject,
         "type": 2,
         "start_time": frappe.utils.get_datetime(starts_on).isoformat(),
-        "duration": duration,
+        "duration": int(duration),
         "timezone": timezone,
         "agenda": description,
     }
@@ -114,7 +114,7 @@ def update_meeting(
         "topic": subject,
         "type": 2,
         "start_time": frappe.utils.get_datetime(starts_on).isoformat(),
-        "duration": duration,
+        "duration": int(duration),
         "timezone": timezone,
         "agenda": description,
     }


### PR DESCRIPTION

## Description

- There was an issue with Zoom integration, that the duration was not reflecting in Zoom Meeting. This was due to type of duration being float, while it should be int. This PR fixes the same.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

- Create a meeting with Zoom as meeting provider, and ensure from the Zoom Dashboard that the duration of that meeting is correct.

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #