### PR TITLE
Fix: Removed check for enable_scheduling_on_weekends since we had removed this field

### DIFF
--- a/frappe_appointment/helpers/zoom.py
+++ b/frappe_appointment/helpers/zoom.py
@@ -66,7 +66,7 @@ def create_meeting(
         "topic": subject,
         "type": 2,
         "start_time": frappe.utils.get_datetime(starts_on).isoformat(),
-        "duration": duration,
+        "duration": int(duration),
         "timezone": timezone,
         "agenda": description,
     }
@@ -114,7 +114,7 @@ def update_meeting(
         "topic": subject,
         "type": 2,
         "start_time": frappe.utils.get_datetime(starts_on).isoformat(),
-        "duration": duration,
+        "duration": int(duration),
         "timezone": timezone,
         "agenda": description,
     }

--- a/frappe_appointment/tasks/verify_availability.py
+++ b/frappe_appointment/tasks/verify_availability.py
@@ -32,9 +32,8 @@ def get_availability_status_for_appointment_group(appointment_group, publish_rea
     if event_availability_window <= 0:
         event_availability_window = 10  # By default, we will check availability for next 10 days only.
     for _ in range(event_availability_window):
-        if appointment_group.enable_scheduling_on_weekends or current_date.weekday() < 5:
-            available_slots = get_time_slots_for_given_date(appointment_group, current_date)
-            data[current_date.date().isoformat()] = available_slots["total_slots_for_day"]
+        available_slots = get_time_slots_for_given_date(appointment_group, current_date)
+        data[current_date.date().isoformat()] = available_slots["total_slots_for_day"]
         current_date = frappe.utils.add_days(current_date, 1)
     appointment_group.reload()
     appointment_group.available_slots_data = json.dumps(data)


### PR DESCRIPTION
## Description

- We had removed the field `enable_scheduling_on_weekends` with #104 and #108 
- Still there was a reference left for the same in `verify_availability.py`. 
- This PR removes the same reference, as it was causing issue.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

- Go to an Appointment Group, click on `Update Slots Availability`. Check for RQ Job, and ensure it doesn't fail.

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #