### PR TITLE
Update meeting time format to hh:mm time format.

### DIFF
--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -167,7 +167,7 @@ export const parseDateString = (dateString: string): Date => {
 // Converts Minute string to Hours and Minutes Format (HH:MM)
 export const convertMinutesToTimeFormat = (
   minutes: number | string,
-  useAbbrForMin: boolean = false
+  useAbbr: boolean = false
 ): string => {
   try {
     const totalMinutes =
@@ -179,7 +179,7 @@ export const convertMinutesToTimeFormat = (
 
     // If minutes less than 60, return as is with "Minute" suffix
     if (totalMinutes < 60) {
-      return `${totalMinutes} ${useAbbrForMin ? "min" : "Minute"}`;
+      return `${totalMinutes} ${useAbbr ? "min" : "Minute"}`;
     }
 
     const hours = Math.floor(totalMinutes / 60);
@@ -188,7 +188,7 @@ export const convertMinutesToTimeFormat = (
     const hoursStr = hours.toString().padStart(2, "0");
     const minutesStr = mins.toString().padStart(2, "0");
 
-    return `${hoursStr}:${minutesStr} ${useAbbrForMin ? "hr" : "Hour"}`;
+    return `${hoursStr}:${minutesStr} ${useAbbr ? "hr" : "Hour"}`;
   } catch (error) {
     console.log(error);
     return "";

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -163,3 +163,34 @@ export const parseDateString = (dateString: string): Date => {
     return new Date();
   }
 };
+
+// Converts Minute string to Hours and Minutes Format (HH:MM)
+export const convertMinutesToTimeFormat = (
+  minutes: number | string,
+  useAbbrForMin: boolean = false
+): string => {
+  try {
+    const totalMinutes =
+      typeof minutes === "string" ? parseInt(minutes, 10) : minutes;
+      
+    if (isNaN(totalMinutes)) {
+      throw new Error("Invalid input: Cannot convert to number");
+    }
+
+    // If minutes less than 60, return as is with "Minute" suffix
+    if (totalMinutes < 60) {
+      return `${totalMinutes} ${useAbbrForMin ? "min" : "Minute"}`;
+    }
+
+    const hours = Math.floor(totalMinutes / 60);
+    const mins = totalMinutes % 60;
+
+    const hoursStr = hours.toString().padStart(2, "0");
+    const minutesStr = mins.toString().padStart(2, "0");
+
+    return `${hoursStr}:${minutesStr} ${useAbbrForMin ? "hr" : "Hour"}`;
+  } catch (error) {
+    console.log(error);
+    return "";
+  }
+};

--- a/frontend/src/pages/appointment/components/booking.tsx
+++ b/frontend/src/pages/appointment/components/booking.tsx
@@ -24,6 +24,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/avatar";
 import Typography from "@/components/typography";
 import {
   cn,
+  convertMinutesToTimeFormat,
   convertToMinutes,
   getAllSupportedTimeZones,
   getTimeZoneOffsetFromTimeZoneString,
@@ -42,7 +43,6 @@ import SuccessAlert from "@/components/success-alert";
 import { Icon } from "@/components/icons";
 import { CalendarWrapper } from "@/components/calendar-wrapper";
 import { useBookingReducer } from "../reducer";
-import { convertMinutesToTimeFormat } from "../utils";
 
 interface BookingProp {
   type: string;

--- a/frontend/src/pages/appointment/components/booking.tsx
+++ b/frontend/src/pages/appointment/components/booking.tsx
@@ -42,6 +42,7 @@ import SuccessAlert from "@/components/success-alert";
 import { Icon } from "@/components/icons";
 import { CalendarWrapper } from "@/components/calendar-wrapper";
 import { useBookingReducer } from "../reducer";
+import { convertMinutesToTimeFormat } from "../utils";
 
 interface BookingProp {
   type: string;
@@ -278,7 +279,7 @@ const Booking = ({ type, banner }: BookingProp) => {
                   {duration ? (
                     <Typography className="text-sm mt-1 flex items-center">
                       <Clock className="inline-block w-4 h-4 mr-1" />
-                      {duration} Minute Meeting
+                      {convertMinutesToTimeFormat(duration)} Meeting
                     </Typography>
                   ) : (
                     <Skeleton className="h-5 w-24" />

--- a/frontend/src/pages/appointment/components/meetingCard.tsx
+++ b/frontend/src/pages/appointment/components/meetingCard.tsx
@@ -17,7 +17,7 @@ import {
 import Typography from "@/components/typography";
 import { useAppContext } from "@/context/app";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/tooltip";
-import { convertMinutesToTimeFormat } from "../utils";
+import { convertMinutesToTimeFormat } from "@/lib/utils";
 
 interface MeetingCardProps {
   title: string;

--- a/frontend/src/pages/appointment/components/meetingCard.tsx
+++ b/frontend/src/pages/appointment/components/meetingCard.tsx
@@ -16,11 +16,8 @@ import {
 } from "@/components/card";
 import Typography from "@/components/typography";
 import { useAppContext } from "@/context/app";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/tooltip";
+import { convertMinutesToTimeFormat } from "../utils";
 
 interface MeetingCardProps {
   title: string;
@@ -35,15 +32,13 @@ const MeetingCard = ({ title, duration, onClick }: MeetingCardProps) => {
       <CardHeader className="space-y-1">
         <CardTitle className="text-xl py-2">
           <Tooltip>
-            <TooltipTrigger>
-              {title}
-            </TooltipTrigger>
+            <TooltipTrigger>{title}</TooltipTrigger>
             <TooltipContent>{title}</TooltipContent>
           </Tooltip>
         </CardTitle>
         <CardDescription className="flex items-center gap-1">
           <Clock className="w-4 h-4 text-blue-500" />
-          <Typography>{duration} min</Typography>
+          <Typography>{convertMinutesToTimeFormat(duration,true)}</Typography>
           <span className="mx-1">•</span>
           <Video className="w-4 h-4 text-blue-400" />
           <Typography className="text-blue-400">

--- a/frontend/src/pages/appointment/utils.ts
+++ b/frontend/src/pages/appointment/utils.ts
@@ -47,33 +47,3 @@ export const getCurrentTime = (timeZone: string) => {
   }
 };
 
-// Converts Minute string to Hours and Minutes Format (HH:MM)
-export const convertMinutesToTimeFormat = (
-  minutes: number | string,
-  useAbbrForMin: boolean = false
-): string => {
-  try {
-    const totalMinutes =
-      typeof minutes === "string" ? parseInt(minutes, 10) : minutes;
-      
-    if (isNaN(totalMinutes)) {
-      throw new Error("Invalid input: Cannot convert to number");
-    }
-
-    // If minutes less than 60, return as is with "Minute" suffix
-    if (totalMinutes < 60) {
-      return `${totalMinutes} ${useAbbrForMin ? "min" : "Minute"}`;
-    }
-
-    const hours = Math.floor(totalMinutes / 60);
-    const mins = totalMinutes % 60;
-
-    const hoursStr = hours.toString().padStart(2, "0");
-    const minutesStr = mins.toString().padStart(2, "0");
-
-    return `${hoursStr}:${minutesStr} ${useAbbrForMin ? "hr" : "Hour"}`;
-  } catch (error) {
-    console.log(error);
-    return "";
-  }
-};

--- a/frontend/src/pages/appointment/utils.ts
+++ b/frontend/src/pages/appointment/utils.ts
@@ -1,7 +1,5 @@
-
-
 // Helper function to format the timezone offset
-export function getTimeZoneOffset(timeZone: string): string {
+export const getTimeZoneOffset = (timeZone: string): string => {
   try {
     const now = new Date();
     const formatter = new Intl.DateTimeFormat("en-US", {
@@ -32,10 +30,10 @@ export function getTimeZoneOffset(timeZone: string): string {
     console.error(e);
     return "";
   }
-}
+};
 
 // Helper function to get current time in timezone
-export function getCurrentTime(timeZone: string) {
+export const getCurrentTime = (timeZone: string) => {
   try {
     return new Date().toLocaleTimeString("en-US", {
       timeZone,
@@ -47,6 +45,35 @@ export function getCurrentTime(timeZone: string) {
     console.log(e);
     return "";
   }
-}
+};
 
+// Converts Minute string to Hours and Minutes Format (HH:MM)
+export const convertMinutesToTimeFormat = (
+  minutes: number | string,
+  useAbbrForMin: boolean = false
+): string => {
+  try {
+    const totalMinutes =
+      typeof minutes === "string" ? parseInt(minutes, 10) : minutes;
+      
+    if (isNaN(totalMinutes)) {
+      throw new Error("Invalid input: Cannot convert to number");
+    }
 
+    // If minutes less than 60, return as is with "Minute" suffix
+    if (totalMinutes < 60) {
+      return `${totalMinutes} ${useAbbrForMin ? "min" : "Minute"}`;
+    }
+
+    const hours = Math.floor(totalMinutes / 60);
+    const mins = totalMinutes % 60;
+
+    const hoursStr = hours.toString().padStart(2, "0");
+    const minutesStr = mins.toString().padStart(2, "0");
+
+    return `${hoursStr}:${minutesStr} ${useAbbrForMin ? "hr" : "Hour"}`;
+  } catch (error) {
+    console.log(error);
+    return "";
+  }
+};

--- a/frontend/src/pages/group-appointment/index.tsx
+++ b/frontend/src/pages/group-appointment/index.tsx
@@ -19,6 +19,7 @@ import Typography from "@/components/typography";
 import {
   capitalizeWords,
   cn,
+  convertMinutesToTimeFormat,
   convertToMinutes,
   getAllSupportedTimeZones,
   getTimeZoneOffsetFromTimeZoneString,
@@ -289,18 +290,18 @@ const GroupAppointment = () => {
                         <Tooltip>
                           <TooltipTrigger className="text-left truncate">
                             <Typography className="truncate font-medium text-gray-600">
-                              {convertToMinutes(
+                              {convertMinutesToTimeFormat(convertToMinutes(
                                 state.meetingData.duration
-                              ).toString()}{" "}
-                              Minute Meeting
+                              ).toString())}{" "}
+                              Meeting
                             </Typography>
                           </TooltipTrigger>
                           <TooltipContent className="capitalize">
                             <span className="text-blue-600">duration</span> :{" "}
-                            {convertToMinutes(
+                            {convertMinutesToTimeFormat(convertToMinutes(
                               state.meetingData.duration
-                            ).toString()}{" "}
-                            Minute Meeting
+                            ).toString())}{" "}
+                            Meeting
                           </TooltipContent>
                         </Tooltip>
                       </div>


### PR DESCRIPTION
## Description

This PR adds a utility function to convert minute string into desired `HH:MM` format, if the meeting duration is more than 60 minutes.

## Relevant Technical Choices

- Add `convertMinutesToTimeFormat` utility
- Update Personal  and Group appointment to support changes

## Testing Instructions

- Open Personal appointment or Group Appointment
- Meeting duration must follow HH:MM format, if the duration is more than 60 minutes 

## Additional Information:

N/A

## Screenshot/Screencast

Group Appointment:
![image](https://github.com/user-attachments/assets/ec450668-940b-4543-8994-077ff0b171bb)

Personal Appointment:

![image](https://github.com/user-attachments/assets/2004416f-a158-4787-a0fb-c57b6f16454d)

![image](https://github.com/user-attachments/assets/5683f278-4ad8-47d6-b031-4e8882bccacf)



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)


Addresses https://github.com/rtCamp/frappe-appointment/issues/157