### PR TITLE
Add Dark Mode & Fix Availability Slot Visibility

### DIFF
--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -19,6 +19,7 @@ import { getSiteName } from "./lib/utils";
 import { TooltipProvider } from "@/components/tooltip";
 import { AppProvider } from "./context/app";
 import { Toaster } from "./components/sonner";
+import ModeToggle from "./components/theme-provider/components/modeToggle";
 
 const App = () => {
   const router = createBrowserRouter(createRoutesFromElements(Router()), {
@@ -40,6 +41,7 @@ const App = () => {
               <Suspense fallback={<></>}>
                 <RouterProvider router={router} />
                 <Toaster />
+                <ModeToggle/>
               </Suspense>
             </TooltipProvider>
           </FrappeProvider>

--- a/frontend/src/components/calendar/index.tsx
+++ b/frontend/src/components/calendar/index.tsx
@@ -41,7 +41,7 @@ function Calendar({
         ),
         day_range_end: "day-range-end",
         day_selected:
-          "bg-blue-500 text-primary-foreground hover:bg-blue-500 hover:text-primary-foreground focus:bg-blue-500 focus:text-primary-foreground",
+          "bg-blue-500 dark:bg-blue-400 text-primary-foreground hover:bg-blue-500 dark:hover:bg-blue-400 hover:text-primary-foreground focus:bg-blue-500 focus:text-primary-foreground",
         day_today: "bg-accent text-accent-foreground",
         day_outside:
           "day-outside text-muted-foreground aria-selected:bg-accent/50 aria-selected:text-muted-foreground",

--- a/frontend/src/components/skeleton/index.tsx
+++ b/frontend/src/components/skeleton/index.tsx
@@ -7,7 +7,7 @@ function Skeleton({
   return (
     <div
       className={cn(
-        "relative overflow-hidden rounded-md bg-blue-50 before:absolute before:inset-0 before:-translate-x-full before:animate-[shimmer_1.5s_infinite] before:bg-gradient-to-r before:from-transparent before:via-blue-100/50 before:to-transparent",
+        "relative overflow-hidden rounded-md bg-blue-50 dark:bg-[hsl(240,4%,18%)] before:absolute before:inset-0 before:-translate-x-full before:animate-[shimmer_1.5s_infinite] before:bg-gradient-to-r before:from-transparent before:via-blue-100/50 dark:before:via-[hsl(220,5%,22%)]/90  before:to-transparent",
         className
       )}
       {...props}

--- a/frontend/src/components/success-alert/index.tsx
+++ b/frontend/src/components/success-alert/index.tsx
@@ -76,14 +76,14 @@ const SuccessAlert = ({
       >
         <DialogHeader>
           <div className="flex justify-center">
-            <div className="w-14 h-14 bg-blue-100 rounded-full flex items-center justify-center">
-              <CircleCheck className="text-blue-500 h-7 w-7" />
+            <div className="w-14 h-14 bg-blue-100 dark:bg-blue-600/20 rounded-full flex items-center justify-center">
+              <CircleCheck className="text-blue-500 dark:text-blue-600 h-7 w-7" />
             </div>
           </div>
           <DialogTitle>
             <Typography
               variant="p"
-              className="text-center text-gray-600 text-lg mb-7"
+              className="text-center text-gray-600 dark:text-foreground text-lg mb-7"
             >
               Your Appointment has been scheduled
             </Typography>
@@ -91,26 +91,26 @@ const SuccessAlert = ({
         </DialogHeader>
 
         <div>
-          <div className="flex items-center justify-between p-4 py-2 bg-gray-50 rounded-lg mb-4">
+          <div className="flex items-center justify-between p-4 py-2 bg-gray-50 dark:bg-zinc-800 rounded-lg mb-4">
             <div className="flex items-center">
               <Calendar className="text-blue-500 transition-colors cursor-pointer h-5 w-5 mr-3" />
               <div>
                 <p className="font-medium text-sm">
                   {format(new Date(selectedSlot.start_time), "MMMM d, yyyy")}
                 </p>
-                <p className="text-xs text-gray-600">
+                <p className="text-xs text-gray-600 dark:text-gray-400">
                   {format(new Date(selectedSlot.start_time), "EEEE, hh:mm a")}
                 </p>
               </div>
             </div>
           </div>
 
-          <div className="flex items-center justify-between p-4 py-2 bg-gray-50 rounded-lg">
+          <div className="flex items-center justify-between p-4 py-2 bg-gray-50 dark:bg-zinc-800 rounded-lg">
             <div className="flex items-center">
               <MapPin className="text-blue-500 transition-colors cursor-pointer h-5 w-5 mr-3" />
               <div>
                 <p className="font-medium text-sm">Virtual Meeting</p>
-                <p className="text-xs text-gray-600">{meetingProvider}</p>
+                <p className="text-xs text-gray-600 dark:text-gray-400">{meetingProvider}</p>
               </div>
             </div>
             {meetLink && (
@@ -122,8 +122,8 @@ const SuccessAlert = ({
         </div>
 
         {calendarString && (
-          <div className="w-full overflow-hidden flex mt-4 px-3 py-1  bg-blue-50 items-center gap-2 max-md:h-14 rounded-full">
-            <span className="w-full text-sm text-gray-500  truncate">
+          <div className="w-full overflow-hidden flex mt-4 px-3 py-1  bg-blue-50 dark:bg-zinc-800 items-center gap-2 max-md:h-14 rounded-full">
+            <span className="w-full text-sm text-gray-500 dark:text-blue-400  truncate">
               {calendarString}
             </span>
             <Button
@@ -153,7 +153,7 @@ const SuccessAlert = ({
                 variant="ghost"
                 onClick={(e) => e.stopPropagation()}
                 size="sm"
-                className="border border-blue-400 hover:text-blue-500 text-blue-500 w-full hover:bg-blue-50 p-4 rounded-full text-sm"
+                className="border border-blue-400 hover:text-blue-500 dark:hover:text-blue-400 text-blue-500 dark:text-blue-400 w-full hover:bg-blue-50 dark:bg-blue-800/10 p-4 rounded-full text-sm"
               >
                 Reschedule
               </Button>
@@ -167,7 +167,7 @@ const SuccessAlert = ({
                 onClose?.();
               }}
               size="sm"
-              className="bg-blue-500 w-full hover:bg-blue-600 p-4 rounded-full text-sm"
+              className="bg-blue-500 dark:bg-blue-400 w-full hover:bg-blue-600 dark:hover:bg-blue-500 p-4 rounded-full text-sm"
             >
               Close
             </Button>

--- a/frontend/src/components/theme-provider/components/modeToggle.tsx
+++ b/frontend/src/components/theme-provider/components/modeToggle.tsx
@@ -3,6 +3,8 @@
  */
 import { useEffect } from "react";
 import { Moon, Sun } from "lucide-react";
+import { AnimatePresence, motion } from "framer-motion";
+
 /**
  * Internal dependencies
  */
@@ -26,39 +28,41 @@ const ModeToggle = () => {
 
   return (
     <>
-      <div className="max-lg:hidden fixed z-50 top-4 right-4 flex items-center p-2 rounded-xl bg-background max-lg:bg-transparent lg:border border-border">
-        <button
-          onClick={toggleTheme}
-          className="relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 bg-muted"
-          aria-label={`Switch to ${theme === "light" ? "dark" : "light"} mode`}
+      <motion.button
+      onClick={toggleTheme}
+      className="fixed bg-background dark:hover:bg-zinc-800 z-50 max-md:top-4 max-md:right-4 top-10 right-5 lg:top-4 lg:right-4  flex gap-2 items-center justify-center rounded-full p-2 lg:px-3 hover:bg-gray-100 focus:outline-none overflow-hidden"
+      aria-label={`Switch to ${theme === "light" ? "dark" : "light"} mode`}
+      whileTap={{ scale: 0.9 }}
+    >
+      <AnimatePresence mode="wait">
+        <motion.div
+          key={theme + "-icon"}
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: -10 }}
+          transition={{ duration: 0.2 }}
         >
-          <span
-            className={`pointer-events-none flex items-center justify-center absolute h-5 w-5 rounded-full bg-background shadow-lg transform ring-0 transition-transform ${
-              theme === "dark" ? "translate-x-5" : "translate-x-0"
-            }`}
-          >
-            {theme === "dark" ? (
-              <Moon className="h-3 w-3 text-foreground" />
-            ) : (
-              <Sun className="h-3 w-3 text-foreground" />
-            )}
-          </span>
-        </button>
-        <span className="max-lg:hidden ml-2 text-sm font-medium text-foreground">
-          {theme === "dark" ? "Dark" : "Light"}
-        </span>
-      </div>
-      <button
-        onClick={toggleTheme}
-        className="lg:hidden fixed bg-background z-50 top-4 right-4 flex items-center justify-center rounded-full p-2 hover:bg-gray-100 dark:hover:bg-gray-800 focus:outline-none "
-        aria-label={`Switch to ${theme === "light" ? "dark" : "light"} mode`}
-      >
-        {theme === "dark" ? (
-          <Moon className="h-4 w-4 text-gray-200" />
-        ) : (
-          <Sun className="h-4 w-4 text-amber-500" />
-        )}
-      </button>
+          {theme === "light" ? (
+            <Moon className="h-4 w-4 text-blue-500 fill-blue-500" />
+          ) : (
+            <Sun className="h-4 w-4 text-amber-500 fill-amber-500" />
+          )}
+        </motion.div>
+      </AnimatePresence>
+
+      <AnimatePresence mode="wait">
+        <motion.span
+          key={theme + "-text"}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.2 }}
+          className="max-lg:hidden text-sm font-medium text-blue-500 dark:text-amber-500"
+        >
+          {theme === "light" ? "Dark" : "Light"}
+        </motion.span>
+      </AnimatePresence>
+    </motion.button>
     </>
   );
 };

--- a/frontend/src/components/theme-provider/components/modeToggle.tsx
+++ b/frontend/src/components/theme-provider/components/modeToggle.tsx
@@ -54,9 +54,9 @@ const ModeToggle = () => {
         aria-label={`Switch to ${theme === "light" ? "dark" : "light"} mode`}
       >
         {theme === "dark" ? (
-          <Moon className="h-5 w-5 text-gray-200" />
+          <Moon className="h-4 w-4 text-gray-200" />
         ) : (
-          <Sun className="h-5 w-5 text-amber-500" />
+          <Sun className="h-4 w-4 text-amber-500" />
         )}
       </button>
     </>

--- a/frontend/src/components/theme-provider/components/modeToggle.tsx
+++ b/frontend/src/components/theme-provider/components/modeToggle.tsx
@@ -1,0 +1,66 @@
+/**
+ * External dependencies
+ */
+import { useEffect } from "react";
+import { Moon, Sun } from "lucide-react";
+/**
+ * Internal dependencies
+ */
+import { useTheme } from "..";
+
+const ModeToggle = () => {
+  const { theme, setTheme } = useTheme();
+
+  useEffect(() => {
+    if (!theme) {
+      const systemPrefersDark = window.matchMedia(
+        "(prefers-color-scheme: dark)"
+      ).matches;
+      setTheme(systemPrefersDark ? "dark" : "light");
+    }
+  }, [theme, setTheme]);
+
+  const toggleTheme = () => {
+    setTheme(theme === "light" ? "dark" : "light");
+  };
+
+  return (
+    <>
+      <div className="max-lg:hidden fixed z-50 top-4 right-4 flex items-center p-2 rounded-xl bg-background max-lg:bg-transparent lg:border border-border">
+        <button
+          onClick={toggleTheme}
+          className="relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 bg-muted"
+          aria-label={`Switch to ${theme === "light" ? "dark" : "light"} mode`}
+        >
+          <span
+            className={`pointer-events-none flex items-center justify-center absolute h-5 w-5 rounded-full bg-background shadow-lg transform ring-0 transition-transform ${
+              theme === "dark" ? "translate-x-5" : "translate-x-0"
+            }`}
+          >
+            {theme === "dark" ? (
+              <Moon className="h-3 w-3 text-foreground" />
+            ) : (
+              <Sun className="h-3 w-3 text-foreground" />
+            )}
+          </span>
+        </button>
+        <span className="max-lg:hidden ml-2 text-sm font-medium text-foreground">
+          {theme === "dark" ? "Dark" : "Light"}
+        </span>
+      </div>
+      <button
+        onClick={toggleTheme}
+        className="lg:hidden fixed bg-background z-50 top-4 right-4 flex items-center justify-center rounded-full p-2 hover:bg-gray-100 dark:hover:bg-gray-800 focus:outline-none "
+        aria-label={`Switch to ${theme === "light" ? "dark" : "light"} mode`}
+      >
+        {theme === "dark" ? (
+          <Moon className="h-5 w-5 text-gray-200" />
+        ) : (
+          <Sun className="h-5 w-5 text-amber-500" />
+        )}
+      </button>
+    </>
+  );
+};
+
+export default ModeToggle;

--- a/frontend/src/components/theme-provider/index.tsx
+++ b/frontend/src/components/theme-provider/index.tsx
@@ -1,0 +1,76 @@
+/**
+ * External dependencies.
+ */
+import { createContext, useContext, useEffect, useState } from "react"
+
+/**
+ * Internal dependencies.
+ */
+import { Theme, ThemeProviderState } from "./types"
+
+
+type ThemeProviderProps = {
+  children: React.ReactNode
+  defaultTheme?: Theme
+  storageKey?: string
+}
+
+const initialState: ThemeProviderState = {
+    theme: "system",
+    setTheme: () => null,
+  }
+
+
+const ThemeProviderContext = createContext<ThemeProviderState>(initialState)
+
+export function ThemeProvider({
+  children,
+  defaultTheme = "system",
+  storageKey = "vite-ui-theme",
+  ...props
+}: ThemeProviderProps) {
+  const [theme, setTheme] = useState<Theme>(
+    () => (localStorage.getItem(storageKey) as Theme) || defaultTheme
+  )
+
+  useEffect(() => {
+    const root = window.document.documentElement
+
+    root.classList.remove("light", "dark")
+
+    if (theme === "system") {
+      const systemTheme = window.matchMedia("(prefers-color-scheme: dark)")
+        .matches
+        ? "dark"
+        : "light"
+
+      root.classList.add(systemTheme)
+      return
+    }
+
+    root.classList.add(theme)
+  }, [theme])
+
+  const value = {
+    theme,
+    setTheme: (theme: Theme) => {
+      localStorage.setItem(storageKey, theme)
+      setTheme(theme)
+    },
+  }
+
+  return (
+    <ThemeProviderContext.Provider {...props} value={value}>
+      {children}
+    </ThemeProviderContext.Provider>
+  )
+}
+
+export const useTheme = () => {
+  const context = useContext(ThemeProviderContext)
+
+  if (context === undefined)
+    throw new Error("useTheme must be used within a ThemeProvider")
+
+  return context
+}

--- a/frontend/src/components/theme-provider/types.ts
+++ b/frontend/src/components/theme-provider/types.ts
@@ -1,0 +1,6 @@
+export type Theme = "dark" | "light" | "system"
+
+export type ThemeProviderState = {
+  theme: Theme
+  setTheme: (theme: Theme) => void
+}

--- a/frontend/src/context/app.tsx
+++ b/frontend/src/context/app.tsx
@@ -14,6 +14,7 @@ import React, {
  */
 import { Profile } from "@/pages/appointment/components/socialProfiles";
 import NetworkDisconnect from "@/components/network-disconnect";
+import { ThemeProvider } from "@/components/theme-provider";
 
 // Define the types for the userInfo and MeetingProviderTypes
 type MeetingProviderTypes = "Google Meet" | "Zoom";
@@ -151,7 +152,9 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({
         setMeetingDurationCards,
       }}
     >
-      {children}
+      <ThemeProvider defaultTheme="system" storageKey="vite-ui-theme">
+        {children}
+      </ThemeProvider>
     </AppContext.Provider>
   );
 };

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -63,6 +63,14 @@
   body {
     @apply bg-background text-foreground;
   }
+  @media (pointer: fine) { /* Only works for precise pointer devices such as laptops and desktops */
+    .dark ::-webkit-scrollbar {
+      @apply w-3 bg-background;
+    }
+    .dark ::-webkit-scrollbar-thumb {
+      @apply bg-secondary
+    }
+  }
 }
 
 html,
@@ -98,7 +106,7 @@ body {
   }
 
   .no-scrollbar:hover::-webkit-scrollbar-track {
-    background: rgba(0, 0, 0, 0.1 );
+    background: rgba(0, 0, 0, 0.1);
   }
 }
 

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -30,9 +30,9 @@
     --radius: 0.5rem;
   }
   .dark {
-    --background: 0 0% 3.9%;
-    --foreground: 0 0% 98%;
-    --card: 0 0% 3.9%;
+    --background: 240 5% 8%;
+    --foreground: 0 0% 95%;
+    --card: 240 6% 10%;
     --card-foreground: 0 0% 98%;
     --popover: 0 0% 3.9%;
     --popover-foreground: 0 0% 98%;

--- a/frontend/src/pages/appointment/components/booking.tsx
+++ b/frontend/src/pages/appointment/components/booking.tsx
@@ -302,7 +302,7 @@ const Booking = ({ type, banner }: BookingProp) => {
                   )}
                 </div>
               </div>
-              <div className="max-lg:w-full shrink-0 md:max-h-[30rem] md:overflow-hidden">
+              <div className="max-lg:w-full shrink-0 md:max-h-[31rem] md:overflow-hidden">
                 {/* Calendar and Availability slots */}
                 <AnimatePresence mode="wait">
                   {!state.showMeetingForm && (
@@ -483,7 +483,7 @@ const Booking = ({ type, banner }: BookingProp) => {
                                           slot.end_time &&
                                         reschedule &&
                                         event_token &&
-                                        "bg-blue-500 dark:bg-blue-400 text-white hover:bg-blue-500 dark:hover:bg-blue-400 hover:text-white"
+                                        "bg-blue-500 dark:bg-blue-400 text-white dark:text-background hover:bg-blue-500 dark:hover:bg-blue-400 hover:text-white dark:hover:text-background"
                                     )}
                                   >
                                     {formatTimeSlot(new Date(slot.start_time))}

--- a/frontend/src/pages/appointment/components/booking.tsx
+++ b/frontend/src/pages/appointment/components/booking.tsx
@@ -221,7 +221,7 @@ const Booking = ({ type, banner }: BookingProp) => {
     <>
       <div className="w-full h-fit flex justify-center">
         <div className="md:w-4xl max-lg:w-full md:p-4 md:py-6 gap-10 md:gap-12">
-          <div className="w-full rounded-xl  md:border border-blue-100 border-t-0">
+          <div className="w-full rounded-xl  md:border border-blue-100 dark:border-zinc-700 border-t-0">
             {/* Banner */}
             <div
               className={cn(
@@ -239,11 +239,11 @@ const Booking = ({ type, banner }: BookingProp) => {
               }
             >
               {/* avatar */}
-              <Avatar className="h-28 w-28 md:h-32 md:w-32 object-cover absolute bottom-0 translate-y-1/2 md:left-24 max-md:left-5 outline outline-white">
+              <Avatar className="h-28 w-28 md:h-32 md:w-32 object-cover absolute bottom-0 translate-y-1/2 md:left-24 max-md:left-5 outline outline-white dark:outline-background">
                 <AvatarImage
                   src={userInfo.userImage}
                   alt="Profile picture"
-                  className="bg-blue-50"
+                  className="bg-blue-50 dark:bg-zinc-800"
                 />
                 <AvatarFallback className="text-4xl">
                   {userInfo.name?.toString()[0]?.toUpperCase()}
@@ -289,13 +289,13 @@ const Booking = ({ type, banner }: BookingProp) => {
                     {formatDate(new Date(), "d MMM, yyyy")}
                   </Typography>
                   {userInfo.meetingProvider.toLowerCase() == "zoom" && (
-                    <Typography className="text-sm text-blue-500 mt-1 flex items-center">
+                    <Typography className="text-sm text-blue-500 dark:text-blue-400 mt-1 flex items-center">
                       <Icon name="zoom" />
                       Zoom
                     </Typography>
                   )}{" "}
                   {userInfo.meetingProvider.toLowerCase() == "google meet" && (
-                    <Typography className="text-sm text-blue-700 mt-1 flex items-center">
+                    <Typography className="text-sm text-blue-700 dark:text-blue-400 mt-1 flex items-center">
                       <Icon name="googleMeet" />
                       Google Meet
                     </Typography>
@@ -374,12 +374,12 @@ const Booking = ({ type, banner }: BookingProp) => {
 
                             {/* Time Format Toggle */}
                             <div className="flex items-center gap-2">
-                              <Typography className="text-sm text-gray-700">
+                              <Typography className="text-sm text-gray-700 dark:text-slate-300">
                                 AM/PM
                               </Typography>
                               <Switch
                                 disabled={rescheduleLoading}
-                                className="data-[state=checked]:bg-blue-500 active:ring-blue-400 focus-visible:ring-blue-400"
+                                className="data-[state=checked]:bg-blue-500 dark:data-[state=checked]:bg-blue-400 active:ring-blue-400 focus-visible:ring-blue-400"
                                 checked={state.timeFormat === "24h"}
                                 onCheckedChange={(checked) => {
                                   dispatch({
@@ -388,7 +388,7 @@ const Booking = ({ type, banner }: BookingProp) => {
                                   });
                                 }}
                               />
-                              <Typography className="text-sm text-gray-700">
+                              <Typography className="text-sm text-gray-700 dark:text-slate-300">
                                 24H
                               </Typography>
                             </div>
@@ -398,10 +398,10 @@ const Booking = ({ type, banner }: BookingProp) => {
 
                       {/* Sticky Bottom Action Bar (Mobile) */}
                       {state.isMobileView && state.expanded && (
-                        <div className="h-14 fixed bottom-0 left-0 w-screen border z-10 bg-white border-top flex items-center justify-between px-4">
+                        <div className="h-14 fixed bottom-0 left-0 w-screen border z-10 bg-background border-top flex items-center justify-between px-4">
                           <Button
                             variant="link"
-                            className="text-blue-500 px-0"
+                            className="text-blue-500 dark:text-blue-400 px-0"
                             onClick={() =>
                               dispatch({ type: "SET_EXPANDED", payload: false })
                             }
@@ -412,7 +412,7 @@ const Booking = ({ type, banner }: BookingProp) => {
                           </Button>
                           {state.showReschedule && (
                             <Button
-                              className="bg-blue-500 hover:bg-blue-500 w-fit px-6"
+                              className="bg-blue-500 dark:bg-blue-400 hover:bg-blue-500 dark:hover:bg-blue-400 w-fit px-6"
                               onClick={onReschedule}
                               disabled={
                                 rescheduleLoading || !state.showReschedule
@@ -476,14 +476,14 @@ const Booking = ({ type, banner }: BookingProp) => {
                                     }}
                                     variant="outline"
                                     className={cn(
-                                      "w-full font-normal border border-blue-500 text-blue-500 hover:text-blue-500 ease-in-out duration-200 hover:bg-blue-50 transition-colors ",
+                                      "w-full font-normal border border-blue-500 dark:border-blue-400 text-blue-500 dark:text-blue-400 hover:text-blue-500 dark:hover:text-blue-400 ease-in-out duration-200 hover:bg-blue-50 dark:hover:bg-blue-800/20 transition-colors ",
                                       selectedSlot.start_time ===
                                         slot.start_time &&
                                         selectedSlot.end_time ===
                                           slot.end_time &&
                                         reschedule &&
                                         event_token &&
-                                        "bg-blue-500 text-white hover:bg-blue-500 hover:text-white"
+                                        "bg-blue-500 dark:bg-blue-400 text-white hover:bg-blue-500 dark:hover:bg-blue-400 hover:text-white"
                                     )}
                                   >
                                     {formatTimeSlot(new Date(slot.start_time))}
@@ -501,7 +501,7 @@ const Booking = ({ type, banner }: BookingProp) => {
                         )}
                         {state.showReschedule && (
                           <Button
-                            className="bg-blue-500 hover:bg-blue-500 lg:!mt-0 max-lg:w-full max-md:hidden"
+                            className="bg-blue-500 dark:bg-blue-400 hover:bg-blue-500 dark:hover:bg-blue-400 lg:!mt-0 max-lg:w-full max-md:hidden"
                             onClick={onReschedule}
                             disabled={rescheduleLoading}
                           >

--- a/frontend/src/pages/appointment/components/booking.tsx
+++ b/frontend/src/pages/appointment/components/booking.tsx
@@ -203,7 +203,7 @@ const Booking = ({ type, banner }: BookingProp) => {
 
   useEffect(() => {
     const handleResize = () => {
-      dispatch({ type: "SET_MOBILE_VIEW", payload: window.innerWidth <= 768 });
+      dispatch({ type: "SET_MOBILE_VIEW", payload: window.innerWidth <= 1024 });
     };
 
     handleResize();
@@ -225,7 +225,7 @@ const Booking = ({ type, banner }: BookingProp) => {
             {/* Banner */}
             <div
               className={cn(
-                "w-full md:rounded-xl md:rounded-b-none relative bg-blue-100 h-40 max-md:mb-20 md:mb-12",
+                "w-full md:rounded-xl md:rounded-b-none relative bg-blue-100 dark:bg-zinc-800 h-40 max-md:mb-20 md:mb-12",
                 banner && "bg-cover bg-center bg-no-repeat"
               )}
               style={
@@ -428,7 +428,7 @@ const Booking = ({ type, banner }: BookingProp) => {
                       <div
                         className={cn(
                           "w-48 shrink-0 max-lg:w-full overflow-hidden space-y-4 max-md:pb-10  transition-all duration-300 ",
-                          !state.expanded && "max-md:hidden",
+                          !state.expanded && "max-lg:hidden",
                           state.showReschedule &&
                             "lg:flex lg:flex-col lg:justify-between"
                         )}

--- a/frontend/src/pages/appointment/components/meetingCard.tsx
+++ b/frontend/src/pages/appointment/components/meetingCard.tsx
@@ -28,7 +28,7 @@ interface MeetingCardProps {
 const MeetingCard = ({ title, duration, onClick }: MeetingCardProps) => {
   const { userInfo } = useAppContext();
   return (
-    <Card className="group transform hover:-translate-y-1 hover:border-blue-300 duration-300 relative overflow-hidden rounded-2xl transition-all hover:shadow-lg">
+    <Card onClick={onClick} className="group cursor-pointer transform hover:-translate-y-1 hover:border-blue-300 dark:hover:border-blue-400 duration-300 relative overflow-hidden rounded-2xl transition-all hover:shadow-lg">
       <CardHeader className="space-y-1">
         <CardTitle className="text-xl py-2">
           <Tooltip>
@@ -48,8 +48,7 @@ const MeetingCard = ({ title, duration, onClick }: MeetingCardProps) => {
       </CardHeader>
       <CardContent className="cursor-pointer">
         <Button
-          onClick={onClick}
-          className="w-full bg-blue-500 hover:bg-blue-500 rounded-2xl"
+          className="w-full bg-blue-500 hover:bg-blue-500 dark:bg-blue-400 dark:hover:bg-blue-400 rounded-2xl"
         >
           Schedule Meeting
         </Button>

--- a/frontend/src/pages/appointment/components/meetingForm.tsx
+++ b/frontend/src/pages/appointment/components/meetingForm.tsx
@@ -280,7 +280,7 @@ const MeetingForm = ({
           <div className="flex justify-between md:pt-4 max-md:h-14 max-md:fixed max-md:bottom-0 max-md:left-0 max-md:w-screen max-md:border max-md:z-10 max-md:bg-background max-md:border-top max-md:items-center max-md:px-4">
             <Button
               type="button"
-              className="text-blue-500 hover:text-blue-600 md:hover:bg-blue-50 md:dark:hover:bg-blue-800/10 max-md:px-0 max-md:hover:underline max-md:hover:bg-transparent"
+              className="text-blue-500 dark:text-blue-400 hover:text-blue-600 dark:hover:text-blue-400 md:hover:bg-blue-50 md:dark:hover:bg-blue-800/10 max-md:px-0 max-md:hover:underline max-md:hover:bg-transparent"
               onClick={onBack}
               variant="ghost"
               disabled={loading}

--- a/frontend/src/pages/appointment/components/meetingForm.tsx
+++ b/frontend/src/pages/appointment/components/meetingForm.tsx
@@ -143,7 +143,7 @@ const MeetingForm = ({
   return (
     <motion.div
       key={2}
-      className={`w-full md:h-[30rem] lg:w-[41rem] shrink-0 md:p-6 md:px-4`}
+      className={`w-full md:h-[31rem] lg:w-[41rem] shrink-0 md:p-6 md:px-4`}
       initial={isMobileView ? {} : { x: "100%" }}
       animate={{ x: 0 }}
       exit={isMobileView ? {} : { x: "100%" }}
@@ -259,7 +259,7 @@ const MeetingForm = ({
                     {form.watch("guests").map((guest) => (
                       <div
                         key={guest}
-                        className="flex items-center gap-1 px-2 py-1 bg-blue-500 text-white rounded-full text-sm"
+                        className="flex items-center gap-1 px-2 py-1 bg-blue-500 dark:bg-blue-400 bg-blue text-white dark:text-background rounded-full text-sm"
                       >
                         <span>{guest}</span>
                         <button
@@ -267,7 +267,7 @@ const MeetingForm = ({
                           onClick={() => removeGuest(guest)}
                           className="hover:text-blue-200"
                         >
-                          <X className="h-3 w-3" />
+                          <X className="h-3 w-3 dark:text-background" />
                         </button>
                       </div>
                     ))}

--- a/frontend/src/pages/appointment/components/meetingForm.tsx
+++ b/frontend/src/pages/appointment/components/meetingForm.tsx
@@ -159,7 +159,7 @@ const MeetingForm = ({
               <Typography variant="p" className="text-2xl">
                 Your contact info
               </Typography>
-              <Typography className="text-sm  mt-1 text-blue-500">
+              <Typography className="text-sm  mt-1 text-blue-500 dark:text-blue-400">
                 <CalendarPlus className="inline-block w-4 h-4 mr-1 md:hidden" />
                 {formatDate(selectedDate, "d MMM, yyyy")}
               </Typography>
@@ -170,18 +170,31 @@ const MeetingForm = ({
               name="fullName"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>
-                    Full Name <span className="text-red-500">*</span>
+                  <FormLabel
+                    className={`${
+                      form.formState.errors.fullName ? "text-red-500" : ""
+                    }`}
+                  >
+                    Full Name{" "}
+                    <span className="text-red-500 dark:text-red-600">*</span>
                   </FormLabel>
                   <FormControl>
                     <Input
                       disabled={loading}
-                      className="active:ring-blue-400 focus-visible:ring-blue-400"
+                      className={`active:ring-blue-400 focus-visible:ring-blue-400 ${
+                        form.formState.errors.fullName
+                          ? "active:ring-red-500 focus-visible:ring-red-500"
+                          : ""
+                      }`}
                       placeholder="John Doe"
                       {...field}
                     />
                   </FormControl>
-                  <FormMessage />
+                  <FormMessage
+                    className={`${
+                      form.formState.errors.fullName ? "text-red-500" : ""
+                    }`}
+                  />
                 </FormItem>
               )}
             />
@@ -191,18 +204,31 @@ const MeetingForm = ({
               name="email"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>
-                    Email <span className="text-red-500">*</span>
+                  <FormLabel
+                    className={`${
+                      form.formState.errors.email ? "text-red-500" : ""
+                    }`}
+                  >
+                    Email{" "}
+                    <span className="text-red-500 dark:text-red-600">*</span>
                   </FormLabel>
                   <FormControl>
                     <Input
                       disabled={loading}
-                      className="active:ring-blue-400 focus-visible:ring-blue-400"
+                      className={`active:ring-blue-400 focus-visible:ring-blue-400 ${
+                        form.formState.errors.email
+                          ? "active:ring-red-500 focus-visible:ring-red-500"
+                          : ""
+                      }`}
                       placeholder="john.Doe@gmail.com"
                       {...field}
                     />
                   </FormControl>
-                  <FormMessage />
+                  <FormMessage
+                    className={`${
+                      form.formState.errors.email ? "text-red-500" : ""
+                    }`}
+                  />
                 </FormItem>
               )}
             />
@@ -211,7 +237,7 @@ const MeetingForm = ({
               <Button
                 type="button"
                 variant="ghost"
-                className="h-auto hover:bg-blue-50 text-blue-500 hover:text-blue-600 "
+                className="h-auto hover:bg-blue-50 dark:hover:bg-blue-800/10 text-blue-500 dark:text-blue-400 hover:text-blue-600 "
                 onClick={() => setIsGuestsOpen(!isGuestsOpen)}
                 disabled={loading}
               >
@@ -251,10 +277,10 @@ const MeetingForm = ({
             </div>
           </div>
 
-          <div className="flex justify-between md:pt-4 max-md:h-14 max-md:fixed max-md:bottom-0 max-md:left-0 max-md:w-screen max-md:border max-md:z-10 max-md:bg-white max-md:border-top max-md:items-center max-md:px-4">
+          <div className="flex justify-between md:pt-4 max-md:h-14 max-md:fixed max-md:bottom-0 max-md:left-0 max-md:w-screen max-md:border max-md:z-10 max-md:bg-background max-md:border-top max-md:items-center max-md:px-4">
             <Button
               type="button"
-              className="text-blue-500 hover:text-blue-600 md:hover:bg-blue-50 max-md:px-0 max-md:hover:underline max-md:hover:bg-transparent"
+              className="text-blue-500 hover:text-blue-600 md:hover:bg-blue-50 md:dark:hover:bg-blue-800/10 max-md:px-0 max-md:hover:underline max-md:hover:bg-transparent"
               onClick={onBack}
               variant="ghost"
               disabled={loading}
@@ -263,7 +289,7 @@ const MeetingForm = ({
             </Button>
             <Button
               disabled={loading}
-              className="bg-blue-500 hover:bg-blue-500"
+              className="bg-blue-500 dark:bg-blue-400 hover:bg-blue-500 dark:hover:bg-blue-400"
               type="submit"
             >
               {loading && <Spinner />} Schedule Meeting

--- a/frontend/src/pages/appointment/components/skeletons.tsx
+++ b/frontend/src/pages/appointment/components/skeletons.tsx
@@ -6,7 +6,7 @@ import { Skeleton } from "@/components/skeleton";
 
 export function ProfileSkeleton() {
   return (
-    <Card className="border-0 shadow-none">
+    <Card className="border-0 shadow-none !bg-transparent bg-gradient-to-b from-blue-100 to-transparent dark:bg-gradient-to-b dark:from-zinc-800">
       <CardContent className="max-md:p-4 p-6 flex flex-col space-y-7 items-center">
         <Skeleton className="md:h-32 md:w-32 h-24 w-24 object-cover mb-4 md:mb-0  rounded-full" />
         <div className="flex flex-col space-y-2 w-full items-center">

--- a/frontend/src/pages/appointment/components/timeZoneSelectmenu.tsx
+++ b/frontend/src/pages/appointment/components/timeZoneSelectmenu.tsx
@@ -44,7 +44,7 @@ export default function TimeZoneSelect({
       <PopoverTrigger disabled={disable} asChild>
         <Button
           variant="outline"
-          className="w-full md:w-fit md:border-none border-blue-100 md:focus:ring-0 hover:bg-blue-50 dark:hover:bg-blue-800/20 hover:text-blue-500 md:focus:ring-offset-0 text-blue-500 dark:text-blue-400"
+          className="w-full md:w-fit md:border-none border-blue-100 dark:border-zinc-800 md:focus:ring-0 hover:bg-blue-50 dark:hover:bg-blue-800/20 hover:text-blue-500 md:focus:ring-offset-0 text-blue-500 dark:text-blue-400"
         >
           <div className="flex justify-center items-center gap-2">
             <Globe className="h-4 w-4" />

--- a/frontend/src/pages/appointment/components/timeZoneSelectmenu.tsx
+++ b/frontend/src/pages/appointment/components/timeZoneSelectmenu.tsx
@@ -44,7 +44,7 @@ export default function TimeZoneSelect({
       <PopoverTrigger disabled={disable} asChild>
         <Button
           variant="outline"
-          className="w-full md:w-fit md:border-none border-blue-100 md:focus:ring-0 hover:bg-blue-50 hover:text-blue-500 md:focus:ring-offset-0 text-blue-500"
+          className="w-full md:w-fit md:border-none border-blue-100 md:focus:ring-0 hover:bg-blue-50 dark:hover:bg-blue-800/20 hover:text-blue-500 md:focus:ring-offset-0 text-blue-500 dark:text-blue-400"
         >
           <div className="flex justify-center items-center gap-2">
             <Globe className="h-4 w-4" />
@@ -71,7 +71,7 @@ export default function TimeZoneSelect({
                   setTimeZone(getLocalTimezone());
                   setOpen(false);
                 }}
-                className="cursor-pointer py-3 px-4 flex items-center gap-2 truncate data-[selected=true]:!bg-blue-50 text-blue-500 data-[selected=true]:!text-blue-500"
+                className="cursor-pointer py-3 px-4 flex items-center gap-2 truncate data-[selected=true]:!bg-blue-50 dark:data-[selected=true]:!bg-blue-800/20 text-blue-500 dark:text-blue-400 data-[selected=true]:!text-blue-500 dark:data-[selected=true]:!text-blue-400"
               >
                 <RefreshCcw className="h-4 w-4 text-blue-500" />
                 <span>Reset to Default Timezone</span>
@@ -83,7 +83,7 @@ export default function TimeZoneSelect({
                     setTimeZone(tz);
                     setOpen(false);
                   }}
-                  className="cursor-pointer py-3 px-4 data-[selected=true]:!bg-blue-50 text-blue-500 data-[selected=true]:!text-blue-500"
+                  className="cursor-pointer py-3 px-4 data-[selected=true]:!bg-blue-50 dark:data-[selected=true]:!bg-blue-800/20 text-blue-500 dark:text-blue-400 data-[selected=true]:!text-blue-500 dark:data-[selected=true]:!text-blue-400"
                 >
                   <div className="flex w-full items-center gap-4">
                     <div className="w-40 truncate">

--- a/frontend/src/pages/appointment/index.tsx
+++ b/frontend/src/pages/appointment/index.tsx
@@ -25,6 +25,7 @@ import {
 import Typography from "@/components/typography";
 import MetaTags from "@/components/meta-tags";
 import { Info } from "lucide-react";
+import ModeToggle from "@/components/theme-provider/components/modeToggle";
 
 const Appointment = () => {
   const { meetId } = useParams();
@@ -99,8 +100,8 @@ const Appointment = () => {
               {isLoading ? (
                 <ProfileSkeleton />
               ) : (
-                <div className="w-full flex flex-col gap-4 p-4 md:p-6 md:px-4 justify-center items-center bg-gradient-to-b from-blue-100 to-transparent md:rounded-2xl">
-                  <Avatar className="md:h-32 md:w-32 h-24 w-24 object-cover mb-4 md:mb-0 hover:outline outline-blue-300 transition-all duration-100">
+                <div className="w-full flex flex-col gap-4 p-4 md:p-6 md:px-4 justify-center items-center bg-gradient-to-b from-blue-100 to-transparent dark:bg-gradient-to-b dark:from-zinc-800 md:rounded-2xl">
+                  <Avatar className="md:h-32 md:w-32 h-24 w-24 object-cover mb-4 md:mb-0 hover:outline outline-blue-300 dark:outline-blue-400/80 transition-all duration-100">
                     <AvatarImage
                       src={userInfo.userImage}
                       alt="Profile picture"
@@ -152,6 +153,7 @@ const Appointment = () => {
                     <p className="text-muted-foreground">
                       You will receive a calendar invite with meeting link.
                     </p>
+                    <ModeToggle/>
                   </div>
                 )}
                 {/* meeting cards */}
@@ -176,7 +178,7 @@ const Appointment = () => {
                     ))
                   )}
                 </div>
-                <div className="mt-4 p-3 md:hidden bg-gray-50 rounded-2xl border border-gray-200 text-sm text-gray-600">
+                <div className="mt-4 p-3 md:hidden bg-gray-50 dark:bg-card rounded-2xl border border-gray-200 dark:border-gray-600 text-sm text-gray-600 dark:text-gray-400">
                   <div className="flex items-center gap-3">
                     <Info className="text-amber-500 size-10" />
                     <p>

--- a/frontend/src/pages/appointment/index.tsx
+++ b/frontend/src/pages/appointment/index.tsx
@@ -104,7 +104,7 @@ const Appointment = () => {
                     <AvatarImage
                       src={userInfo.userImage}
                       alt="Profile picture"
-                      className="bg-blue-50"
+                      className="bg-blue-50 dark:bg-zinc-800"
                     />
                     <AvatarFallback className="text-4xl">
                       {userInfo?.name?.toString()[0]?.toUpperCase()}

--- a/frontend/src/pages/appointment/index.tsx
+++ b/frontend/src/pages/appointment/index.tsx
@@ -25,7 +25,6 @@ import {
 import Typography from "@/components/typography";
 import MetaTags from "@/components/meta-tags";
 import { Info } from "lucide-react";
-import ModeToggle from "@/components/theme-provider/components/modeToggle";
 
 const Appointment = () => {
   const { meetId } = useParams();
@@ -100,7 +99,7 @@ const Appointment = () => {
               {isLoading ? (
                 <ProfileSkeleton />
               ) : (
-                <div className="w-full flex flex-col gap-4 p-4 md:p-6 md:px-4 justify-center items-center bg-gradient-to-b from-blue-100 to-transparent dark:bg-gradient-to-b dark:from-zinc-800 md:rounded-2xl">
+                <div className="w-full flex flex-col gap-4 p-4 md:p-6 max-lg:md:pt-10 md:px-4 justify-center items-center bg-gradient-to-b from-blue-100 to-transparent dark:bg-gradient-to-b dark:from-zinc-800 md:rounded-2xl">
                   <Avatar className="md:h-32 md:w-32 h-24 w-24 object-cover mb-4 md:mb-0 hover:outline outline-blue-300 dark:outline-blue-400/80 transition-all duration-100">
                     <AvatarImage
                       src={userInfo.userImage}
@@ -153,7 +152,6 @@ const Appointment = () => {
                     <p className="text-muted-foreground">
                       You will receive a calendar invite with meeting link.
                     </p>
-                    <ModeToggle/>
                   </div>
                 )}
                 {/* meeting cards */}

--- a/frontend/src/pages/appointment/index.tsx
+++ b/frontend/src/pages/appointment/index.tsx
@@ -17,11 +17,7 @@ import { useAppContext } from "@/context/app";
 import { Skeleton } from "@/components/skeleton";
 import { getLocalTimezone } from "@/lib/utils";
 import PoweredBy from "@/components/powered-by";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/tooltip";
 import Typography from "@/components/typography";
 import MetaTags from "@/components/meta-tags";
 import { Info } from "lucide-react";
@@ -76,7 +72,7 @@ const Appointment = () => {
         userImage: data?.message?.profile_pic,
         socialProfiles: [],
         meetingProvider: data?.message?.meeting_provider,
-        banner_image:data?.message?.banner_image,
+        banner_image: data?.message?.banner_image,
       });
       setMeetingDurationCards(data?.message?.durations);
     }
@@ -88,7 +84,7 @@ const Appointment = () => {
   return (
     <>
       <MetaTags
-        title={`${userInfo.name} | Appointment`}
+        title={userInfo.name ? `${userInfo.name} | Appointment` : "Appointment"}
         description={`Book appointment with ${userInfo.name}`}
       />
       {!type || isLoading ? (

--- a/frontend/src/pages/group-appointment/index.tsx
+++ b/frontend/src/pages/group-appointment/index.tsx
@@ -255,13 +255,13 @@ const GroupAppointment = () => {
                               key={key}
                               className="flex cursor-default items-center gap-2 w-full "
                             >
-                              <div className="w-full truncate text-gray-600 flex items-center justify-start gap-2">
+                              <div className="w-full truncate text-gray-600 dark:text-gray-400 flex items-center justify-start gap-2">
                                 <Icon className="h-4 w-4 shrink-0" />
                                 <Tooltip>
                                   <TooltipTrigger className="text-left truncate">
                                     <Typography
                                       className={cn(
-                                        "truncate font-medium text-gray-600",
+                                        "truncate font-medium text-gray-600 dark:text-gray-400",
                                         key.includes("name") &&
                                           "text-foreground",
                                         key.includes("email")
@@ -285,11 +285,11 @@ const GroupAppointment = () => {
                         }
                       )}
                     <div className="flex cursor-default items-center gap-2 w-full ">
-                      <div className="w-full truncate text-gray-600 flex items-center justify-start gap-2">
+                      <div className="w-full truncate text-gray-600 dark:text-gray-400 flex items-center justify-start gap-2">
                         <Clock className="h-4 w-4 shrink-0" />
                         <Tooltip>
                           <TooltipTrigger className="text-left truncate">
-                            <Typography className="truncate font-medium text-gray-600">
+                            <Typography className="truncate font-medium text-gray-600 dark:text-gray-400">
                               {convertMinutesToTimeFormat(convertToMinutes(
                                 state.meetingData.duration
                               ).toString())}{" "}
@@ -379,10 +379,10 @@ const GroupAppointment = () => {
               </div>
             )}
             {state.isMobileView && state.expanded && (
-              <div className="h-14 fixed bottom-0 left-0 w-screen border z-10 bg-white border-top flex items-center justify-between px-4">
+              <div className="h-14 fixed bottom-0 left-0 w-screen border z-10 bg-background border-top flex items-center justify-between px-4">
                 <Button
                   variant="link"
-                  className="text-blue-500 px-0"
+                  className="text-blue-500 dark:text-blue-400 px-0"
                   onClick={() =>
                     dispatch({ type: "SET_EXPANDED", payload: false })
                   }
@@ -399,7 +399,7 @@ const GroupAppointment = () => {
                       : true) || loading
                   }
                   className={cn(
-                    "bg-blue-500 flex hover:bg-blue-500 w-fit px-10",
+                    "bg-blue-500 dark:bg-blue-400 flex hover:bg-blue-500 dark:hover:bg-blue-400 w-fit px-10",
                     "md:hidden"
                   )}
                   onClick={scheduleMeeting}
@@ -450,12 +450,12 @@ const GroupAppointment = () => {
                             disabled={loading}
                             variant="outline"
                             className={cn(
-                              "w-full font-normal border border-blue-500 text-blue-500 hover:text-blue-500 hover:bg-blue-50 transition-colors ",
+                              "w-full font-normal border border-blue-500 dark:border-blue-400 text-blue-500 dark:text-blue-400 hover:text-blue-500 dark:hover:text-blue-400 hover:bg-blue-50 dark:hover:bg-blue-800/10 transition-colors ",
                               state.selectedSlot?.start_time ===
                                 slot.start_time &&
                                 state.selectedSlot?.end_time ===
                                   slot.end_time &&
-                                "bg-blue-500 text-white hover:bg-blue-500 hover:text-white"
+                                "bg-blue-500 dark:bg-blue-400 text-background dark:text-background hover:bg-blue-500 dark:hover:bg-blue-400 hover:text-background dark:hover:text-background"
                             )}
                           >
                             {formatTimeSlot(new Date(slot.start_time))}
@@ -473,7 +473,7 @@ const GroupAppointment = () => {
                   <Button
                     disabled={loading}
                     className={cn(
-                      "bg-blue-500 hover:bg-blue-500 lg:!mt-0 max-lg:w-full hidden",
+                      "bg-blue-500 dark:bg-blue-400 hover:bg-blue-500 dark:hover:bg-blue-400 lg:!mt-0 max-lg:w-full hidden",
                       state.selectedSlot?.start_time &&
                         state.selectedSlot.end_time &&
                         "flex",


### PR DESCRIPTION
## Description

This PR introduces `dark mode` support for `frappe-appointment` and resolves an issue where availability slots were hidden on screens between 768px and 1024px.

## Relevant Technical Choices

- Integrate ShadCN's `ThemeProvider` for centralized theme management across the app.  
- Adjust `isMobileView` state logic to resolve the availability slot visibility issue.

## Testing Instructions

- Click theme toggle button at the top right of the screen and verify UI visibility and consistency across the app.  
- Test the application on screen sizes between `768px` and `1024px` to ensure proper layout and functionality.

## Additional Information:

> N/A

## Screenshot/Screencast

Personal Meeting:

![image](https://github.com/user-attachments/assets/bd6e2735-e4d6-463f-888b-1b25634448c5)

![image](https://github.com/user-attachments/assets/a74b4331-a037-4c24-9366-119b0b30f557)

Appointment Group Meeting:

![image](https://github.com/user-attachments/assets/5c4f3a2c-74d5-4baa-ae5e-8d65890d8cef)





## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)


Fixes https://github.com/rtCamp/frappe-appointment/issues/189