### PR TITLE
Send Email Notification to the organizer when event is scheduled

### DIFF
--- a/frappe_appointment/frappe_appointment/doctype/appointment_settings/appointment_settings.json
+++ b/frappe_appointment/frappe_appointment/doctype/appointment_settings/appointment_settings.json
@@ -11,6 +11,9 @@
   "default_group_email_template",
   "column_break_burh",
   "default_availability_alerts_email_template",
+  "email_template_for_organisers_section",
+  "personal_organisers_email_template",
+  "column_break_ovdk",
   "zoom_settings_section",
   "enable_zoom",
   "zoom_account_id",
@@ -96,12 +99,29 @@
    "fieldtype": "Password",
    "hidden": 1,
    "label": "Access Token"
+  },
+  {
+   "fieldname": "email_template_for_organisers_section",
+   "fieldtype": "Section Break",
+   "label": "Email Template for Organisers"
+  },
+  {
+   "default": "[Default] Appointment Scheduled - Organisers",
+   "fieldname": "personal_organisers_email_template",
+   "fieldtype": "Link",
+   "label": "Personal Organisers Email Template",
+   "options": "Email Template"
+  },
+  {
+   "fieldname": "column_break_ovdk",
+   "fieldtype": "Column Break"
   }
  ],
+ "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-03-21 18:23:23.804358",
+ "modified": "2025-04-07 14:00:43.769567",
  "modified_by": "Administrator",
  "module": "Frappe Appointment",
  "name": "Appointment Settings",
@@ -118,6 +138,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/frappe_appointment/hooks.py
+++ b/frappe_appointment/hooks.py
@@ -26,7 +26,10 @@ app_include_js = [
 after_migrate = "frappe_appointment.tasks.setup_erpnext_fields.setup_erpnext_fields"
 
 before_install = "frappe_appointment.tasks.import_email_templates.import_email_templates"
-after_sync = ["frappe_appointment.tasks.setup_erpnext_fields.setup_erpnext_fields", "frappe_appointment.tasks.import_form_tour_google_calendar.import_doc"]
+after_sync = [
+    "frappe_appointment.tasks.setup_erpnext_fields.setup_erpnext_fields",
+    "frappe_appointment.tasks.import_form_tour_google_calendar.import_doc",
+]
 
 # include js, css files in header of web template
 # web_include_css = "/assets/frappe_appointment/css/frappe_appointment.css"
@@ -100,31 +103,6 @@ fixtures = [
                 "in",
                 {
                     "Frappe Appointment",
-                },
-            ]
-        ],
-    },
-    {
-        "dt": "Email Template",
-        "filters": [
-            [
-                "name",
-                "in",
-                {
-                    "[Default] Appointment Scheduled",
-                    "[Default] Appointment Group Availability",
-                },
-            ]
-        ],
-    },
-    {
-        "dt": "Form Tour",
-        "filters": [
-            [
-                "name",
-                "in",
-                {
-                    "Google Calendar Setup",
                 },
             ]
         ],

--- a/frappe_appointment/tasks/import_email_templates.py
+++ b/frappe_appointment/tasks/import_email_templates.py
@@ -33,6 +33,22 @@ EMAIL_TEMPLATES = [
         "subject": "[Frappe Appointment] Appointment Scheduled - {{ event.subject }}",
         "use_html": 0,
     },
+    {
+        "custom_schedule_sending_email": "Send after",
+        "custom_sender_email": "hr@example.com",
+        "custom_time": -1,
+        "custom_time_to_send_email": 0,
+        "docstatus": 0,
+        "doctype": "Email Template",
+        "enabled": 1,
+        "modified": "2025-04-07 11:51:57.165792",
+        "name": "[Default] Appointment Scheduled - Organisers",
+        "reference_doctype": "Appointment Group",
+        "response": '<div class="ql-editor read-mode"><p>Hello,</p><p><br></p><p>A new meeting has been scheduled about {{ event.subject }}.</p><p>{% set formatted_starts_on = frappe.utils.get_datetime(event.starts_on) %}</p><p><br></p><p>The appointment is scheduled for {{ formatted_starts_on.strftime(\'%A\') }}, {{ formatted_starts_on.strftime(\'%d %B %Y\') }} at {{ formatted_starts_on.strftime("%I:%M %P") }} IST.</p><p><br></p><p>Please join the meeting using this link: {{ meet_link }}</p><p><br></p><p><span style="color: rgb(0, 0, 0); background-color: transparent;">Regards,</span></p><p><span style="color: rgb(18, 19, 23);">--</span></p></div>',
+        "response_html": None,
+        "subject": "[Frappe Appointment] Appointment Scheduled - {{ event.subject }}",
+        "use_html": 0,
+    },
 ]
 
 


### PR DESCRIPTION
## Description

Ref: #191 

- Send email notifications to organisers aswell on scheduling of personal meetings.

## Relevant Technical Choices

- Currently, email for organisers will be only sent for personal meetings. Will figure out later if this is required in group meetings aswell or not.

## Testing Instructions

- Scheduling a personal meeting should trigger an email to organiser aswell.

## Additional Information:

- Please modify the email template `[Default] Appointment Scheduled - Organisers` to add company related branding, and set the new email template in `Appointment Settings`

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

See #191 