### PR TITLE
Fix overflow issues in availability slots

### DIFF
--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -102,11 +102,11 @@ body {
 
   /* Show scrollbar on hover */
   .no-scrollbar:hover::-webkit-scrollbar-thumb {
-    background: rgba(0, 0, 0, 0.2);
+    background: rgba(55, 55, 55, 0.2);
   }
 
   .no-scrollbar:hover::-webkit-scrollbar-track {
-    background: rgba(0, 0, 0, 0.1);
+    background: rgba(55, 55, 55, 0.1);
   }
 }
 

--- a/frontend/src/pages/appointment/components/booking.tsx
+++ b/frontend/src/pages/appointment/components/booking.tsx
@@ -221,7 +221,7 @@ const Booking = ({ type, banner }: BookingProp) => {
     <>
       <div className="w-full h-fit flex justify-center">
         <div className="md:w-4xl max-lg:w-full md:p-4 md:py-6 gap-10 md:gap-12">
-          <div className="w-full rounded-xl  md:border border-blue-100 dark:border-zinc-700 border-t-0">
+          <div className="w-full rounded-xl  md:border border-blue-100 dark:border-zinc-800 border-t-0">
             {/* Banner */}
             <div
               className={cn(
@@ -302,7 +302,7 @@ const Booking = ({ type, banner }: BookingProp) => {
                   )}
                 </div>
               </div>
-              <div className="max-lg:w-full shrink-0 md:max-h-[31rem] md:overflow-hidden">
+              <div className="max-lg:w-full shrink-0 lg:max-h-[31rem] md:overflow-hidden">
                 {/* Calendar and Availability slots */}
                 <AnimatePresence mode="wait">
                   {!state.showMeetingForm && (

--- a/frontend/src/pages/appointment/components/meetingForm.tsx
+++ b/frontend/src/pages/appointment/components/meetingForm.tsx
@@ -259,7 +259,7 @@ const MeetingForm = ({
                     {form.watch("guests").map((guest) => (
                       <div
                         key={guest}
-                        className="flex items-center gap-1 px-2 py-1 bg-blue-500 dark:bg-blue-400 bg-blue text-white dark:text-background rounded-full text-sm"
+                        className="flex items-center gap-1 px-2 py-1 bg-blue-500 dark:bg-blue-400 text-white dark:text-background rounded-full text-sm"
                       >
                         <span>{guest}</span>
                         <button


### PR DESCRIPTION
## Description

This PR fixes overflow issues caused due to `max-height` in `md` devices

## Relevant Technical Choices

- Add `max-height` class in large screens instead of md screens

## Testing Instructions

- Go to your personal meeting page.
- Available slots should be scrollable.

## Additional Information:

> N/A

## Screenshot/Screencast


https://github.com/user-attachments/assets/c95b2440-7b14-46d8-8dca-efcadaa6dd38




## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)
