### PR TITLE
feat: Add button to filter appointment group by current user

### DIFF
--- a/frappe_appointment/frappe_appointment/doctype/appointment_group/appointment_group_list.js
+++ b/frappe_appointment/frappe_appointment/doctype/appointment_group/appointment_group_list.js
@@ -1,0 +1,12 @@
+frappe.listview_settings["Appointment Group"] = {
+  onload: function (listview) {
+    const user = frappe.session.user;
+    listview.page.add_button(__("My Appointments"), function () {
+      listview.filter_area.add([["Members", "user", "=", user]]);
+      frappe.show_alert({
+        message: __("Filtering by {0} in member list", [user]),
+        indicator: "green",
+      });
+    });
+  },
+};

--- a/frappe_appointment/frappe_appointment/doctype/appointment_group/appointment_group_list.js
+++ b/frappe_appointment/frappe_appointment/doctype/appointment_group/appointment_group_list.js
@@ -1,7 +1,7 @@
 frappe.listview_settings["Appointment Group"] = {
   onload: function (listview) {
     const user = frappe.session.user;
-    listview.page.add_button(__("My Appointments"), function () {
+    listview.page.add_button(__("Filter My Groups"), function () {
       listview.filter_area.add([["Members", "user", "=", user]]);
       frappe.show_alert({
         message: __("Filtering by {0} in member list", [user]),


### PR DESCRIPTION
## Description

- Add a button in Appointment Group, to filter the list and show only the appointment groups where the current user is a member.
- Ref: #183 

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #183