### PR TITLE
Update GitHub workflow runners based on repo visibility

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   pre-commit:
     name: "Frappe Linter"
-    runs-on: ubuntu-latest
+\1\2 self-hostedtu-latest
     container:
       image: alpine:latest # latest used here for simplicity, not recommended
     defaults:

--- a/.github/workflows/vulnerable_dependency_check.yml
+++ b/.github/workflows/vulnerable_dependency_check.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   deps-vulnerable-check:
     name: Vulnerable Dependency Check
-    runs-on: ["self-hosted", "python"]
+\1\2 self-hostedted", "python"]
     container:
       image: python:latest
     defaults:


### PR DESCRIPTION
This PR updates workflow files to use appropriate runners. Public repos use ubuntu-latest, private repos use self-hosted runners.