### PR TITLE
Workflow: Build Test: Optimise for Open Source Apps and PR's

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -28,7 +28,15 @@ jobs:
       - name: Get APP and Build
         run: |
           cd /home/frappe/frappe-bench
-          su frappe bash -c "bench get-app https://rtbot:${{ secrets.RTBOT_TOKEN }}@github.com/${{ github.repository }} --branch ${{ github.head_ref || github.ref_name }}"
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            REPO="${{ github.event.pull_request.head.repo.full_name }}"
+            BRANCH="${{ github.event.pull_request.head.ref }}"
+          else
+            REPO="${{ github.repository }}"
+            BRANCH="${{ github.head_ref || github.ref_name }}"
+          fi
+          echo "Cloning from $REPO at branch $BRANCH"
+          su frappe bash -c "bench get-app https://github.com/${REPO} --branch ${BRANCH}"
 
       - name: Cleanup
         if: ${{ always() }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Get APP and Build
         run: |
           cd /home/frappe/frappe-bench
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
             REPO="${{ github.event.pull_request.head.repo.full_name }}"
             BRANCH="${{ github.event.pull_request.head.ref }}"
           else


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to improve the handling of repository and branch information when cloning an app during the build process. The changes ensure compatibility with both pull request events and other event types.

### Workflow improvements:

* [`.github/workflows/build-test.yml`](diffhunk://#diff-063ca77e012f959eba648db60e6868875fd1e70e5f5ac081193d848f8d61ef32L31-R39): Updated the `Get APP and Build` step to dynamically determine the repository and branch based on the event type. For pull requests, it now uses the source repository and branch (`github.event.pull_request.head.repo.full_name` and `github.event.pull_request.head.ref`). For other events, it defaults to the repository and branch from the workflow context (`github.repository` and `github.head_ref || github.ref_name`). Added a log statement to display the repository and branch being cloned.