### PR TITLE
Fix: Skip sending reminders for disabled users in Google Calendar

### DIFF
--- a/frappe_appointment/tasks/reminder_google_calendar_auth.py
+++ b/frappe_appointment/tasks/reminder_google_calendar_auth.py
@@ -18,6 +18,9 @@ def send_reminder_mail():
 
         for google_calendar in google_calendars:
             google_calendar = frappe.get_doc("Google Calendar", google_calendar.name)
+            user = frappe.get_doc("User", google_calendar.user)
+            if not user.enabled:
+                continue
             if google_calendar.user == google_calendar.google_calendar_id:
                 if not google_calendar_authorized(google_calendar):
                     frappe.db.set_value(


### PR DESCRIPTION
## Description

- Currently, the cron sending reminder emails for non-authorized google calendar didn't considered if user is enabled or not.
- This PR updates the cron to only sends the reminder to user who are enabled.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

cc @KanchanChauhan 