### PR TITLE
Fix event permissions, allow date range in get_time_slot api.

### DIFF
--- a/frappe_appointment/api/personal_meet.py
+++ b/frappe_appointment/api/personal_meet.py
@@ -101,12 +101,15 @@ def get_time_slots(
         }
 
         date = start_date
+        cache_dict = {}
         while True:
             datetime = frappe.utils.get_datetime(date)
             enddatetime = frappe.utils.get_datetime(end_date)
             if datetime > enddatetime:
                 break
-            _data = _get_time_slots_for_day(appointment_group, date, user_timezone_offset)
+            _data = _get_time_slots_for_day(
+                appointment_group, date, user_timezone_offset, time_slot_cache_dict=cache_dict
+            )
             if _data["is_invalid_date"]:
                 date = _data["next_valid_date"]
                 if not isinstance(_data["next_valid_date"], str):

--- a/frappe_appointment/api/personal_meet.py
+++ b/frappe_appointment/api/personal_meet.py
@@ -245,6 +245,7 @@ def create_dummy_appointment_group(duration, user_availability):
     appointment_group_obj = {
         "doctype": "Appointment Group",
         "group_name": "Personal Meeting",
+        "name": "dummy_appointment_group_personal_meeting",
         "event_creator": user_availability.get("google_calendar"),
         "event_organizer": user_availability.get("user"),
         "members": [{"user": user_availability.get("name"), "is_mandatory": 1}],

--- a/frappe_appointment/api/personal_meet.py
+++ b/frappe_appointment/api/personal_meet.py
@@ -63,7 +63,15 @@ def get_meeting_windows(slug):
 
 @frappe.whitelist(allow_guest=True)
 @add_response_code
-def get_time_slots(duration_id: str, date: str, user_timezone_offset: str):
+def get_time_slots(
+    duration_id: str, date: str = None, user_timezone_offset: str = None, start_date: str = None, end_date: str = None
+):
+    if not date and not (start_date and end_date):
+        return {"error": "Date is required"}, 400
+
+    if not user_timezone_offset:
+        return {"error": "User timezone offset is required"}, 400
+
     duration = frappe.get_doc("Appointment Slot Duration", duration_id)
 
     user_availability = frappe.get_all(
@@ -79,7 +87,43 @@ def get_time_slots(duration_id: str, date: str, user_timezone_offset: str):
 
     appointment_group = frappe.get_doc(appointment_group_obj)
 
-    data = _get_time_slots_for_day(appointment_group, date, user_timezone_offset)
+    if date:
+        data = _get_time_slots_for_day(appointment_group, date, user_timezone_offset)
+    else:
+        data = {
+            "all_available_slots_for_data": [],
+            "dates": [],
+            "duration": None,
+            "starttime": None,
+            "endtime": None,
+            "total_slots": 0,
+            "available_days": [],
+        }
+
+        date = start_date
+        while True:
+            datetime = frappe.utils.get_datetime(date)
+            enddatetime = frappe.utils.get_datetime(end_date)
+            if datetime > enddatetime:
+                break
+            _data = _get_time_slots_for_day(appointment_group, date, user_timezone_offset)
+            if _data["is_invalid_date"]:
+                date = _data["next_valid_date"]
+                if not isinstance(_data["next_valid_date"], str):
+                    date = _data["next_valid_date"].strftime("%Y-%m-%d")
+            else:
+                data["all_available_slots_for_data"].extend(_data["all_available_slots_for_data"])
+                data["dates"].append(_data["date"])
+                data["duration"] = _data["duration"]
+                data["starttime"] = (
+                    min(_data["starttime"], data["starttime"]) if data["starttime"] else _data["starttime"]
+                )
+                data["endtime"] = max(_data["endtime"], data["endtime"]) if data["endtime"] else _data["endtime"]
+                data["total_slots"] += _data["total_slots_for_day"]
+                for available_day in _data["available_days"]:
+                    if available_day not in data["available_days"]:
+                        data["available_days"].append(available_day)
+                date = frappe.utils.add_days(date, 1)
 
     if not data:
         return None

--- a/frappe_appointment/frappe_appointment/doctype/appointment_group/appointment_group.py
+++ b/frappe_appointment/frappe_appointment/doctype/appointment_group/appointment_group.py
@@ -105,6 +105,7 @@ def _get_time_slots_for_day(appointment_group: object, date: str, user_timezone_
             filtered_slots.append(slot)
 
         time_slots_today_object["all_available_slots_for_data"] = filtered_slots
+        time_slots_today_object["total_slots_for_day"] = len(filtered_slots)
 
         return time_slots_today_object
     except GoogleBadRequest as e:

--- a/frappe_appointment/hooks.py
+++ b/frappe_appointment/hooks.py
@@ -155,10 +155,10 @@ fixtures = [
 # permission_query_conditions = {
 # 	"Event": "frappe.desk.doctype.event.event.get_permission_query_conditions",
 # }
-#
-# has_permission = {
-# 	"Event": "frappe.desk.doctype.event.event.has_permission",
-# }
+
+has_permission = {
+    "Event": "frappe_appointment.overrides.event_override.has_permission",
+}
 
 # DocType Class
 # ---------------

--- a/frappe_appointment/overrides/event_override.py
+++ b/frappe_appointment/overrides/event_override.py
@@ -861,7 +861,11 @@ def get_personal_meetings(user, past_events=False):
         else:
             event["ends_on"] = frappe.utils.format_datetime(ends_on, "MMM dd, yyyy, HH:mm")
 
-        duration = frappe.get_doc("Appointment Slot Duration", duration_id)
+        try:
+            duration = frappe.get_doc("Appointment Slot Duration", duration_id)
+        except Exception:
+            duration = None
+            frappe.clear_last_message()
         allow_rescheduling = duration.allow_rescheduling if duration else 0
 
         event["url"] = "/app/event/" + event["name"]

--- a/frappe_appointment/overrides/event_override.py
+++ b/frappe_appointment/overrides/event_override.py
@@ -391,6 +391,20 @@ class EventOverride(Event):
             return {"status": False, "message": "Unable to create an event"}
 
 
+def has_permission(doc, user):
+    if user == "Administrator":
+        return True
+    if doc.event_type == "Public" or doc.owner == user:
+        return True
+    doctype_links = doc.custom_doctype_link_with_event
+    for doctype_link in doctype_links:
+        reference_doctype = doctype_link.reference_doctype
+        reference_docname = doctype_link.reference_docname
+        if frappe.has_permission(reference_doctype, "read", reference_docname):
+            return True
+    return False
+
+
 def send_meet_email(doc, appointment_group, user_calendar, metadata, ics_event_description=None):
     """Sent the meeting link email to the given user using the provided Email Template"""
     doc.reload()


### PR DESCRIPTION
## Description

- This PR introduces the following changes:
    - [Handle exception when retrieving appointment slot duration](https://github.com/rtCamp/frappe-appointment/commit/ea8b06e8b68e3854669cd37d7090abe33dd981ab): This error used to occur when user deleted his Available Duration, and there is already a meeting scheduled with that duration.
    - [Implement custom permission logic for event access](https://github.com/rtCamp/frappe-appointment/commit/f99bab42633fb3adceece49a11fbbd7fee41de83): Allows users to access those events in which they have access to the document in `Doctype Link with Event`
    - [Allow passing date_range in get_time_slots api](https://github.com/rtCamp/frappe-appointment/commit/ed87a663b0821a610f87da8662e0b227e381fe77): Ref: #227 
    - [Enhance multi-date time slot retrieval by adding caching mechanism](https://github.com/rtCamp/frappe-appointment/commit/0e4e98dc5626ace022787172fa87e20bc933f70b): When fetching slots, we call Calendar API to fetch events for yesterday and today (or today and tomorrow) based on timezone. Now, when fetching slots for a date range, this caused duplicate calls to google API. This commit ensures that the response is cached, and it reduces the overall time to fetch slots for daterange by half. Also, added a name aswell to the dummy appointment group, to create a valid cache dict.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #227 