### PR TITLE
Remove dummy appointment group name and prevent email template from updation on migrate

### DIFF
--- a/frappe_appointment/api/personal_meet.py
+++ b/frappe_appointment/api/personal_meet.py
@@ -245,7 +245,6 @@ def create_dummy_appointment_group(duration, user_availability):
     appointment_group_obj = {
         "doctype": "Appointment Group",
         "group_name": "Personal Meeting",
-        "name": "dummy_appointment_group_personal_meeting",
         "event_creator": user_availability.get("google_calendar"),
         "event_organizer": user_availability.get("user"),
         "members": [{"user": user_availability.get("name"), "is_mandatory": 1}],

--- a/frappe_appointment/frappe_appointment/doctype/appointment_group/appointment_group.py
+++ b/frappe_appointment/frappe_appointment/doctype/appointment_group/appointment_group.py
@@ -179,14 +179,11 @@ def hours_to_time_slot(start_time, user_timezone_offset, current_time=None) -> i
 
 def get_time_slots_for_given_date(appointment_group: object, datetime: datetime, time_slot_cache_dict=None):
     if time_slot_cache_dict is not None:
-        if appointment_group.name in time_slot_cache_dict:
-            if datetime in time_slot_cache_dict[appointment_group.name]:
-                return time_slot_cache_dict[appointment_group.name][datetime]
-        else:
-            time_slot_cache_dict[appointment_group.name] = {}
+        if datetime in time_slot_cache_dict:
+            return time_slot_cache_dict[datetime]
     data = _get_time_slots_for_given_date(appointment_group, datetime)
     if time_slot_cache_dict is not None:
-        time_slot_cache_dict[appointment_group.name][datetime] = data
+        time_slot_cache_dict[datetime] = data
     return data
 
 

--- a/frappe_appointment/tasks/import_email_templates.py
+++ b/frappe_appointment/tasks/import_email_templates.py
@@ -57,17 +57,7 @@ def import_email_templates():
         try:
             frappe.get_doc(email_template).insert(ignore_permissions=True)
         except frappe.DuplicateEntryError:
-            # update the existing template
-            existing_template = frappe.get_doc("Email Template", email_template["name"])
-            for key, value in email_template.items():
-                if key not in [
-                    "doctype",
-                    "name",
-                    "modified",
-                    "docstatus",
-                ]:  # Avoid updating fields that should not be changed
-                    existing_template.set(key, value)
-            existing_template.save(ignore_permissions=True)
+            pass  # Do not update existing templates
         except Exception as e:
             print(f"Error importing email template {email_template['name']}: {e}")
             continue


### PR DESCRIPTION
## Description

- This PR fixes the following:
    - Remove name from dummy appointment group.
    - Prevent updating existing email templates during migration

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast




## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #