### PR TITLE
Bump dependencies to fix packages vulnerabilities

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -52,7 +52,7 @@
         "tailwindcss": "^3.4.6",
         "typescript": "~5.6.2",
         "typescript-eslint": "^8.18.2",
-        "vite": "^6.0.5"
+        "vite": "^6.4.1"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -56,7 +56,7 @@
     "tailwindcss": "^3.4.6",
     "typescript": "~5.6.2",
     "typescript-eslint": "^8.18.2",
-    "vite": "^6.0.5"
+    "vite": "^6.4.1"
   },
   "overrides": {
     "glob": "^11.0.0"

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,7 +2,7 @@ import path from "path";
 import react from "@vitejs/plugin-react";
 import { defineConfig, loadEnv } from "vite";
 
-export default defineConfig(({ command, mode }) => {
+export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), "");
   let proxyConfig = {};
   if (env.VITE_SITE_NAME && env.VITE_SITE_PORT) {


### PR DESCRIPTION
## Description

This PR bumps following packages:
- Bumps Frappe React SDK to 1.13.0
- Bump vite to `6.4.1`
- Add Glob `11.0.0` override


## Testing Instructions

> Test individual and group appointment scheduling workflows
cc: @shivamsn97 


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [ ] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Addresses:
- https://github.com/rtCamp/frappe-appointment/security/dependabot/13
- https://github.com/rtCamp/frappe-appointment/security/dependabot/19
- https://github.com/rtCamp/frappe-appointment/security/dependabot/18
- https://github.com/rtCamp/frappe-appointment/security/dependabot/23
- https://github.com/rtCamp/frappe-appointment/security/dependabot/10
- https://github.com/rtCamp/frappe-appointment/security/dependabot/21
- https://github.com/rtCamp/frappe-appointment/security/dependabot/15
- https://github.com/rtCamp/frappe-appointment/security/dependabot/16
- https://github.com/rtCamp/frappe-appointment/security/dependabot/11