### PR TITLE
Fix/out of office event visibility

### DIFF
--- a/frappe_appointment/helpers/out_of_office.py
+++ b/frappe_appointment/helpers/out_of_office.py
@@ -30,6 +30,7 @@ def create_out_of_office_google_calander_event(
             "end": date_object.get("end"),
             "eventType": "outOfOffice",  # Note this will only work for organazation email addresses
             "summary": "Out of Office",
+            "visibility": "public",
         }
 
         event = google_calendar.events().insert(calendarId="primary", body=event).execute()


### PR DESCRIPTION
## Description

This pull request makes a minor update to the creation of Google Calendar events for out-of-office notifications. The change sets the event visibility to "public" to ensure the event is visible to others.

* Added `"visibility": "public"` to the event payload in the `create_out_of_office_google_calander_event` function in `frappe_appointment/helpers/out_of_office.py`

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #