### PR TITLE
fix: allow_property_change method to include meta

### DIFF
--- a/frappe_appointment/overrides/customize_form_override.py
+++ b/frappe_appointment/overrides/customize_form_override.py
@@ -9,7 +9,7 @@ class AppointmentOverrideCustomizeForm(CustomizeForm):
         CustomizeForm (class): Default class
     """
 
-    def allow_property_change(self, prop, meta_df, df):
+    def allow_property_change(self, prop, meta_df, df, meta):
         """
         Check if a given property can be exported or not
 
@@ -30,4 +30,4 @@ class AppointmentOverrideCustomizeForm(CustomizeForm):
 
         if prop == "options" and df.get("fieldtype") == "Select":
             return True
-        return super().allow_property_change(prop, meta_df, df)
+        return super().allow_property_change(prop, meta_df, df, meta)


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->

The bug is the customise form  had 4 field in v-15 and v-16 has 5. so, Meta changes are not preserved and function crashes.ref - [Frappe Line diff
](https://github.com/frappe/frappe/blob/03d887747bb9b000262373f3532e434e8a47c588/frappe/custom/doctype/customize_form/customize_form.py#L328)

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions
Produce error:
- try changing the perm level of any Doctype by customise form 
<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #