### PR TITLE
Update email_template to use its name property

### DIFF
--- a/frappe_appointment/helpers/email.py
+++ b/frappe_appointment/helpers/email.py
@@ -41,7 +41,7 @@ def send_email_template_mail(doc, args, email_template, recipients=None, attachm
             "recipients": recipients[0],
             "reference_doctype": doc.doctype,
             "reference_name": doc.name,
-            "email_template": email_template.name,
+            "email_template": email_template.name if email_template else None,
             "message_id": get_string_between("<", get_message_id(), ">"),
             "communication_type": "Communication",
             "has_attachment": 1 if attachments else 0,

--- a/frappe_appointment/helpers/email.py
+++ b/frappe_appointment/helpers/email.py
@@ -41,7 +41,7 @@ def send_email_template_mail(doc, args, email_template, recipients=None, attachm
             "recipients": recipients[0],
             "reference_doctype": doc.doctype,
             "reference_name": doc.name,
-            "email_template": email_template,
+            "email_template": email_template.name,
             "message_id": get_string_between("<", get_message_id(), ">"),
             "communication_type": "Communication",
             "has_attachment": 1 if attachments else 0,


### PR DESCRIPTION
## Description

This pull request makes a targeted update to how email templates are referenced when sending emails. Specifically, it changes the value assigned to the `email_template` field from the entire template object to just its `name` attribute, likely to ensure compatibility with downstream consumers expecting a string identifier.

- Changed the `email_template` field in the email sending helper (`send_email_template_mail` in `frappe_appointment/helpers/email.py`) to use `email_template.name` instead of passing the full object.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [ ] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #